### PR TITLE
Use Honeywell keypad update reports to maintain partition and zone status

### DIFF
--- a/custom_components/envisalink_new/controller.py
+++ b/custom_components/envisalink_new/controller.py
@@ -260,7 +260,6 @@ class EnvisalinkController:
     @callback
     def async_multi_updated_callback(self, data):
         """Handle keypad updates with partition and zone data."""
-        LOGGER.debug('we are here')
         LOGGER.debug("Envisalink '%s' sent a partition update event. Updating partitions: %r", self.alarm_name, data['partitions'])
         self._process_state_change(STATE_UPDATE_TYPE_PARTITION, data['partitions'])
         if data['zone_update']:

--- a/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
+++ b/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
@@ -55,6 +55,7 @@ class EnvisalinkAlarmPanel:
         self._commandResponseCallback = self._defaultCallback
         self._pollResponseCallback = self._defaultCallback
         self._keypadUpdateCallback = self._defaultCallback
+        self._hwKeypadUpdateCallback = self._defaultCallback
         self._zoneStateChangeCallback = self._defaultCallback
         self._partitionStateChangeCallback = self._defaultCallback
         self._cidEventCallback = self._defaultCallback
@@ -202,6 +203,14 @@ class EnvisalinkAlarmPanel:
     @callback_keypad_update.setter
     def callback_keypad_update(self, value):
         self._keypadUpdateCallback = value
+
+    @property
+    def callback_hw_keypad_update(self):
+        return self._hwKeypadUpdateCallback
+
+    @callback_hw_keypad_update.setter
+    def callback_hw_keypad_update(self, value):
+        self._hwKeypadUpdateCallback = value
 
     @property
     def callback_zone_state_change(self):

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -13,7 +13,7 @@ class HoneywellClient(EnvisalinkClient):
     """Represents a honeywell alarm client."""
 
     def __init__(self, panel, loop):
-        super().__init__(self, panel, loop)
+        super().__init__(panel, loop)
         self._zoneTimers = {}
 
     def handle_zone_timer_dump(self, code, data):
@@ -177,7 +177,21 @@ class HoneywellClient(EnvisalinkClient):
         alpha = dataList[4]
         partition_status = get_partition_state(flags, alpha)
         zone_code = get_zone_report_type(flags,alpha)
-        _LOGGER.debug("Updating our local alarm state...")
+        try:
+            # ready seems to already be populated by this point, but trap in case of error.
+            prior_ready = self._alarmPanel.alarm_state['partition'][partitionNumber]['status']['ready']
+        except:
+            _LOGGER.debug(f'Ready state unknown for partition {partitionNumber}')
+            prior_ready = False
+        try:
+            # This will throw an error the first time through after start up.
+            prior_bypass = self._alarmPanel.alarm_state['partition'][partitionNumber]['status']['armed_bypass']
+        except:
+            _LOGGER.debug(f'Bypass state unknown for partition {partitionNumber}')
+            prior_bypass = True
+
+        # TODO "armed_bypass" is included in the state below but just passes the bypass flag. How is that used?
+        # TODO "bypass" is part of "status" but isn't updated below.
         self._alarmPanel.alarm_state['partition'][partitionNumber]['status'].update({'alarm': bool(flags.alarm), 'alarm_in_memory': bool(flags.alarm_in_memory), 'armed_away': bool(flags.armed_away),
                                                                    'ac_present': bool(flags.ac_present), 'armed_bypass': bool(flags.bypass), 'chime': bool(flags.chime),
                                                                    'armed_zero_entry_delay': bool(flags.armed_zero_entry_delay), 'alarm_fire_zone': bool(flags.alarm_fire_zone),
@@ -185,7 +199,7 @@ class HoneywellClient(EnvisalinkClient):
                                                                    'armed_stay': bool(flags.armed_stay), 'alpha': alpha, 'beep': beep, 'exit_delay': (partition_status == 'arming') and (zone_code == 'notready'),
                                                                    })
 
-        if partition_status == 'ready':
+        if (partition_status == 'ready') and not prior_ready:
             # Clear all zones known to be in this partition
             _LOGGER.debug(f'Clear partition {partitionNumber}')
             for z in list(self._zoneTimers[partitionNumber]):
@@ -196,20 +210,21 @@ class HoneywellClient(EnvisalinkClient):
                 if timer[1] == 'state':
                     self._alarmPanel.alarm_state['zone'][int(timer[0])]['status'].update({'open':False, 'fault': False})
                 self._zoneTimers[partitionNumber].pop(z)
-        if self._alarmPanel.alarm_state['partition'][partitionNumber]['status']['armed_bypass'] and not bool(flags.bypass):
+
+        if prior_bypass and not bool(flags.bypass):
             # Partition has switched from bypassed to not bypassed, so clear bypass flags
-            # TODO Check whether prior state was bypassed in the condition above.
             # TODO Need to know which bypassed zones are in which partition to handle this. No zone timers for these - either maintain a list or add partition to zone status
             _LOGGER.debug('Clear bypassed zones')
 
         if bool(flags.not_used2) and bool(flags.not_used3):
             # Keypad update is giving partition status. Battery report applies to system battery
-            _LOGGER.debug(f"Keypad update is giving partition {partitionNumber} status.")
+            _LOGGER.debug(f"Keypad update is giving partition {partitionNumber} status. Partition: {partition_status} Zonecode: {zone_code}")
             self._alarmPanel.alarm_state['partition'][partitionNumber]['status'].update({'bat_trouble': bool(flags.low_battery)})
             
-        elif (partition_status == 'arming') and (zone_code == 'notready'):
-            # Keypad is counting down. Nothing to do
-            _LOGGER.debug(f"Keypad is counting down to arm partition {partitionNumber}.")
+            if (partition_status == 'arming') and (zone_code == 'notready'):
+                # Keypad is counting down. Nothing to do
+                # TODO Add entry_delay to %00 update handler
+                _LOGGER.debug(f"Keypad is counting down to arm partition {partitionNumber}.")
 
         elif isinstance(user_zone_field, int):
             # Keypad is giving zone status. Update zone status and check zone timers
@@ -230,6 +245,7 @@ class HoneywellClient(EnvisalinkClient):
                 results['bypass_update'] = True
             elif zone_code in ['alarm','alarmcleared','notready']:
                 # Zone is open
+                # TODO There is a "last_tripped_time" attribute that was previously populated based on zone timer dumps. Does that add enough value to merit reproducing?
                 self._alarmPanel.alarm_state['zone'][user_zone_field]['status'].update({'open': True, 'fault': True})
                 self._zoneTimers[partitionNumber][f"{user_zone_field}|state"] = 1
                 results['zones'].append(user_zone_field)
@@ -238,7 +254,7 @@ class HoneywellClient(EnvisalinkClient):
             # Check and kill any overdue timers
             active_timers = len(self._zoneTimers[partitionNumber])
             #TODO Is this the right margin to add?
-            max_timer = round(active_timers * 1.5 + 2, 0)
+            max_timer = round(active_timers * 2 + 2, 0)
             for z in list(self._zoneTimers[partitionNumber]):
                 if self._zoneTimers[partitionNumber][z] > max_timer:
                     _LOGGER.debug(f'Timer {z} :: {self._zoneTimers[partitionNumber][z]} Closing')
@@ -264,7 +280,6 @@ class HoneywellClient(EnvisalinkClient):
     def handle_partition_state_change(self, code, data):
         """Handle when the envisalink sends us a partition change."""
         # Ignore these EVL-generated messages in favor of the raw keypad updates directly from the panel
-        # TODO Add entry_delay to %00 update handler
         """
         for currentIndex in range(0, 8):
             partitionStateCode = data[currentIndex * 2:(currentIndex * 2) + 2]

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -188,7 +188,7 @@ class HoneywellClient(EnvisalinkClient):
         results['partitions'].append(partitionNumber)
         flags = IconLED_Flags()
         flags.asShort = int(dataList[1], 16)
-        # user_zone_field = int(dataList[2])
+        user_zone_field = int(dataList[2])
         beep = evl_Virtual_Keypad_How_To_Beep.get(dataList[3], "unknown")
         alpha = dataList[4]
         partition_status = get_partition_state(flags, alpha)

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_envisalinkdefs.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_envisalinkdefs.py
@@ -32,6 +32,46 @@ class IconLED_Flags( ctypes.Union ):
                ]
     _anonymous_ = ("b")
 
+def get_partition_state(flags, alpha):
+    if bool(flags.alarm) or bool(flags.alarm_fire_zone) or bool(flags.fire):
+        return 'alarm'
+    elif bool(flags.alarm_in_memory):
+        return 'alarmcleared'
+    elif alpha.find('You may exit now') != -1:
+        return 'arming'
+    elif alpha.find('May Exit Now') != -1:
+        return 'arming'
+    elif bool(flags.armed_stay) and bool(flags.armed_zero_entry_delay):
+        return 'armedinstant'
+    elif bool(flags.armed_away) and bool(flags.armed_zero_entry_delay):
+        return 'armedmax'
+    elif bool(flags.armed_stay):
+        return 'armedstay'
+    elif bool(flags.armed_away):
+        return 'armedaway'
+    elif bool(flags.ready):
+        return 'ready'
+    elif not bool(flags.ready):
+        return 'notready'
+    else:
+        return 'unknown'
+
+def get_zone_report_type(flags, alpha):
+    if bool(flags.alarm) or bool(flags.alarm_fire_zone) or bool(flags.fire):
+        return "alarm"
+    elif bool(flags.alarm_in_memory):
+        return "alarmcleared"
+    elif bool(flags.system_trouble):
+        return 'tamper'
+    elif bool(flags.low_battery):
+        return 'battery'
+    elif bool(flags.bypass) and (alpha.find('BYPAS') != -1):
+        return 'bypass'
+    elif not bool(flags.ready):
+        return 'notready'
+    else:
+        return 'unknown'
+
 evl_Commands = {
     'KeepAlive' : '00',
     'ChangeDefaultPartition' : '01',
@@ -50,7 +90,7 @@ evl_ResponseTypes = {
     'OK' : {'name' : 'Login Success', 'description' : 'Send During Session Login Only, successful login', 'handler' : 'login_success'},
     'FAILED' : {'name' : 'Login Failure', 'description' : 'Sent During Session Login Only, password not accepted', 'handler' : 'login_failure'},
     'Timed Out!' : {'name' : 'Login Interaction Timed Out', 'description' : 'Sent during Session Login Only, socket connection is then closed', 'handler' : 'login_timeout'},
-    '%00' : {'name' : 'Virtual Keypad Update', 'description' : 'The panel wants to update the state of the keypad','handler' : 'keypad_update'},
+    '%00' : {'name' : 'Virtual Keypad Update', 'description' : 'The panel wants to update the state of the keypad','handler' : 'hw_keypad_update'},
     '%01' : {'type' : 'zone', 'name' : 'Zone State Change', 'description' : 'A zone change-of-state has occurred', 'handler' : 'zone_state_change'},
     '%02' : {'type' : 'partition', 'name' : 'Partition State Change', 'description' : 'A partition change-of-state has occured', 'handler' : 'partition_state_change'},
     '%03' : {'type' : 'system', 'name' : 'Realtime CID Event', 'description' : 'A system event has happened that is signaled to either the Envisalerts servers or the central monitoring station', 'handler' : 'realtime_cid_event'},


### PR DESCRIPTION
For Honeywell panels, keypad updates (%02 reports) are now used to track zone and partition status.
- Zones are closed immediately when the partition they are assigned to closes. This provides very fast zone closure when a single zone is faulted.
- Zone timers are tracked to determine the number of keypad updates since the last reported zone fault. Separate timers are also maintained for zone tamper and battery warnings, which are also part of the keypad update queue. This will eventually allow tamper and battery status to be reported for individual zones.
- Zones are assumed closed when they have not reported as being faulted in a keypad update for a certain period. Currently the threshold is when the zone timer exceeds `2n+2`, where `n` is the number of active zone timers. This should reduce zone flapping when multiple zones are open.

Zone Timer Dumps are now ignored, and polling for them is not recommended. Other reports generated based on the Envisalink's logic (%01 and %02 reports) are also ignored.