### PR TITLE
Add bypass switches to HONEYWELL

### DIFF
--- a/custom_components/envisalink_new/config_flow.py
+++ b/custom_components/envisalink_new/config_flow.py
@@ -193,7 +193,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         }
 
         # Add DSC-only options
-        if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_DSC:
+        if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_HONEYWELL:
             # Zone bypass switches are only available on DSC panels
             options_schema[
                 vol.Optional(

--- a/custom_components/envisalink_new/config_flow.py
+++ b/custom_components/envisalink_new/config_flow.py
@@ -190,21 +190,15 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 CONF_TIMEOUT,
                 default=self.config_entry.options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             ): vol.Coerce(int),
-        }
-
-        # Add DSC-only options
-        if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_HONEYWELL:
-            # Zone bypass switches are only available on DSC panels
-            options_schema[
-                vol.Optional(
+            # Zone bypass switches
+            vol.Optional(
+                CONF_CREATE_ZONE_BYPASS_SWITCHES,
+                default=self.config_entry.options.get(
                     CONF_CREATE_ZONE_BYPASS_SWITCHES,
-                    default=self.config_entry.options.get(
-                        CONF_CREATE_ZONE_BYPASS_SWITCHES,
-                        DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
-                    ),
-                )
-            ] = selector.BooleanSelector()
-
+                    DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
+                ),
+            ) = selector.BooleanSelector()
+        }
         # Add Honeywell-only options
         if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_HONEYWELL:
             # Allow selection of which keypress to use for Arm Night mode

--- a/custom_components/envisalink_new/config_flow.py
+++ b/custom_components/envisalink_new/config_flow.py
@@ -197,7 +197,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_CREATE_ZONE_BYPASS_SWITCHES,
                     DEFAULT_CREATE_ZONE_BYPASS_SWITCHES,
                 ),
-            ) = selector.BooleanSelector()
+            ): selector.BooleanSelector()
         }
         # Add Honeywell-only options
         if self.config_entry.data.get(CONF_PANEL_TYPE) == PANEL_TYPE_HONEYWELL:

--- a/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
@@ -286,6 +286,10 @@ class EnvisalinkClient:
     async def toggle_zone_bypass(self, zone):
         """Public method to toggle a zone's bypass state."""
         raise NotImplementedError()
+        
+    async def toggle_chime(self):
+        """Public method to toggle chime mode."""
+        raise NotImplementedError()
 
     async def command_output(self, code, partitionNumber, outputNumber):
         """Public method to activate the selected command output"""

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -112,6 +112,14 @@ class HoneywellClient(EnvisalinkClient):
     async def panic_alarm(self, panicType):
         """Public method to raise a panic alarm."""
         await self.keypresses_to_partition(1, evl_PanicTypes[panicType])
+        
+    async def toggle_zone_bypass(self, code, zone):
+        """Public method to toggle a zone's bypass state."""
+        await self.keypresses_to_partition(1, code + "6" + zone + "*")
+        
+    async def toggle_chime(self, code):
+        """Public method to toggle a zone's bypass state."""
+        await self.keypresses_to_partition(1, code + "9")
 
     def parseHandler(self, rawInput):
         """When the envisalink contacts us- parse out which command and data."""

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -117,9 +117,9 @@ class HoneywellClient(EnvisalinkClient):
         """Public method to toggle a zone's bypass state."""
         await self.keypresses_to_partition(1, '%s6%s*' % (code, zone))
         
-    async def toggle_chime(self, code):
-        """Public method to toggle a zone's bypass state."""
-        await self.keypresses_to_partition(1, code + "9")
+
+
+
 
     def parseHandler(self, rawInput):
         """When the envisalink contacts us- parse out which command and data."""

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -115,7 +115,7 @@ class HoneywellClient(EnvisalinkClient):
         
     async def toggle_zone_bypass(self, zone, code="4112"):
         """Public method to toggle a zone's bypass state."""
-        await self.keypresses_to_partition(1, code + "6" + zone + "*")
+        await self.keypresses_to_partition(1, code & "6" & zone & "*")
         
     async def toggle_chime(self, code):
         """Public method to toggle a zone's bypass state."""

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -113,7 +113,7 @@ class HoneywellClient(EnvisalinkClient):
         """Public method to raise a panic alarm."""
         await self.keypresses_to_partition(1, evl_PanicTypes[panicType])
         
-    async def toggle_zone_bypass(self, code, zone):
+    async def toggle_zone_bypass(self, zone, code="4112"):
         """Public method to toggle a zone's bypass state."""
         await self.keypresses_to_partition(1, code + "6" + zone + "*")
         

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -116,10 +116,6 @@ class HoneywellClient(EnvisalinkClient):
     async def toggle_zone_bypass(self, zone, code="4112"):
         """Public method to toggle a zone's bypass state."""
         await self.keypresses_to_partition(1, '%s6%s*' % (code, zone))
-        
-
-
-
 
     def parseHandler(self, rawInput):
         """When the envisalink contacts us- parse out which command and data."""

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -115,7 +115,7 @@ class HoneywellClient(EnvisalinkClient):
         
     async def toggle_zone_bypass(self, zone, code="4112"):
         """Public method to toggle a zone's bypass state."""
-        await self.keypresses_to_partition(1, code & "6" & zone & "*")
+        await self.keypresses_to_partition(1, '%s6%s*' % (code, zone)
         
     async def toggle_chime(self, code):
         """Public method to toggle a zone's bypass state."""

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -115,7 +115,7 @@ class HoneywellClient(EnvisalinkClient):
         
     async def toggle_zone_bypass(self, zone, code="4112"):
         """Public method to toggle a zone's bypass state."""
-        await self.keypresses_to_partition(1, '%s6%s*' % (code, zone)
+        await self.keypresses_to_partition(1, '%s6%s*' % (code, zone))
         
     async def toggle_chime(self, code):
         """Public method to toggle a zone's bypass state."""

--- a/custom_components/envisalink_new/switch.py
+++ b/custom_components/envisalink_new/switch.py
@@ -40,7 +40,7 @@ async def async_setup_entry(
             for zone_num in zone_set:
                 zone_entry = find_yaml_info(zone_num, zone_info)
 
-                entity = EnvisalinkSwitch(
+                entity = EnvisalinkBypassSwitch(
                     hass,
                     zone_num,
                     zone_entry,
@@ -51,7 +51,7 @@ async def async_setup_entry(
             async_add_entities(entities)
 
 
-class EnvisalinkSwitch(EnvisalinkDevice, SwitchEntity):
+class EnvisalinkBypassSwitch(EnvisalinkDevice, SwitchEntity):
     """Representation of an Envisalink switch."""
 
     def __init__(self, hass, zone_number, zone_info, controller):


### PR DESCRIPTION
So it works, the only question is how you want me to insert ‘code’. For the time being, I am using a default Vista installer code in honeywell_client.py on line 116. I think I need to bring it in to the SwitchEntity unless you have a better way to pass it through.

In this PR:
Changed the ConfigFlow to have Bypass switch creation for all panels.
Add bypass switch command to Honeywell client
Rename EnvisalinkSwitch to EnvisalinkBypassSwitch in preparation for future PR :)