### PR TITLE
Promote panel and zone attributes to entities.

### DIFF
--- a/custom_components/envisalink_new/__init__.py
+++ b/custom_components/envisalink_new/__init__.py
@@ -4,13 +4,11 @@ from __future__ import annotations
 from copy import deepcopy
 from typing import Any
 
-from .pyenvisalink.const import PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL
+import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-
 from homeassistant import config_entries
 from homeassistant.const import CONF_CODE, CONF_HOST, CONF_TIMEOUT, Platform
 from homeassistant.core import HomeAssistant, callback
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -44,6 +42,7 @@ from .const import (
 )
 from .controller import EnvisalinkController
 from .helpers import generate_range_string
+from .pyenvisalink.const import PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL
 
 PLATFORMS: list[Platform] = [
     Platform.ALARM_CONTROL_PANEL,
@@ -130,9 +129,7 @@ def _async_find_matching_config_entry(
     return None
 
 
-async def async_setup_entry(
-    hass: HomeAssistant, entry: config_entries.ConfigEntry
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: config_entries.ConfigEntry) -> bool:
     """Set up Envisalink from a config entry."""
 
     # As there currently is no way to import options from yaml

--- a/custom_components/envisalink_new/binary_sensor.py
+++ b/custom_components/envisalink_new/binary_sensor.py
@@ -83,6 +83,12 @@ _attribute_sensor_info = {
             "device_class": BinarySensorDeviceClass.BATTERY,
             "zone_set": CONF_WIRELESS_ZONE_SET,
         },
+        "fault": {
+            "name": "Fault",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:alarm-light",
+            "device_class": BinarySensorDeviceClass.GAS,
+        },
     },
 }
 
@@ -117,11 +123,16 @@ async def async_setup_entry(
 
             for attr, info in _attribute_sensor_info["zone"].items():
                 if controller.controller.panel_type in info["panels"]:
-                    enable_spec: str = entry.options.get(info.get("zone_set"), "")
-                    enabled_zones = parse_range_string(
-                        enable_spec, min_val=1, max_val=controller.controller.max_zones
-                    )
-                    if enabled_zones and zone_num in enabled_zones:
+                    should_create = True
+                    zone_set_option = info.get("zone_set")
+                    if zone_set_option:
+                        enable_spec: str = entry.options.get(zone_set_option, "")
+                        enabled_zones = parse_range_string(
+                            enable_spec, min_val=1, max_val=controller.controller.max_zones
+                        )
+                        should_create = enabled_zones and zone_num in enabled_zones
+
+                    if should_create:
                         entity = EnvisalinkAttributeBinarySensor(
                             hass,
                             "zone",

--- a/custom_components/envisalink_new/binary_sensor.py
+++ b/custom_components/envisalink_new/binary_sensor.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import datetime
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_LAST_TRIP_TIME
 from homeassistant.core import HomeAssistant
@@ -12,6 +15,9 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    CONF_PARTITION_SET,
+    CONF_PARTITIONNAME,
+    CONF_PARTITIONS,
     CONF_ZONE_SET,
     CONF_ZONENAME,
     CONF_ZONES,
@@ -22,7 +28,61 @@ from .const import (
 )
 from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
 from .models import EnvisalinkDevice
-from .pyenvisalink.const import STATE_CHANGE_ZONE
+from .pyenvisalink.const import (
+    PANEL_TYPE_DSC,
+    PANEL_TYPE_HONEYWELL,
+    STATE_CHANGE_PARTITION,
+    STATE_CHANGE_ZONE,
+)
+
+_attribute_sensor_info = {
+    "partition": {
+        "ac_present": {
+            "name": "AC Power",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:power-plug",
+            "device_class": BinarySensorDeviceClass.POWER,
+        },
+        "ready": {
+            "name": "Ready",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:check",
+            "device_class": None,
+        },
+        "bat_trouble": {
+            "name": "Panel Battery",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:battery-alert",
+            "device_class": BinarySensorDeviceClass.PROBLEM,
+        },
+        "trouble": {
+            "name": "Panel Health",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:alert",
+            "device_class": BinarySensorDeviceClass.PROBLEM,
+        },
+        "fire": {
+            "name": "Fire",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:fire",
+            "device_class": BinarySensorDeviceClass.SMOKE,
+        },
+        "alarm": {
+            "name": "Alarm",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:alarm-light",
+            "device_class": None,
+        },
+    },
+    "zone": {
+        "low_battery": {
+            "name": "Wireless Sensor Battery",
+            "panels": [PANEL_TYPE_DSC],
+            "icon": "mdi:battery-alert",
+            "device_class": BinarySensorDeviceClass.BATTERY,
+        },
+    },
+}
 
 
 async def async_setup_entry(
@@ -32,14 +92,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up the zone binary sensors based on a config entry."""
     controller = hass.data[DOMAIN][entry.entry_id]
+    entities = []
 
+    # Setup zone sensors
     zone_spec: str = entry.data.get(CONF_ZONE_SET, "")
     zone_set = parse_range_string(
         zone_spec, min_val=1, max_val=controller.controller.max_zones
     )
 
     zone_info = entry.data.get(CONF_ZONES)
-    entities = []
     if zone_set is not None:
         for zone_num in zone_set:
             zone_entry = find_yaml_info(zone_num, zone_info)
@@ -52,7 +113,42 @@ async def async_setup_entry(
             )
             entities.append(entity)
 
-        async_add_entities(entities)
+            for attr, info in _attribute_sensor_info["zone"].items():
+                if controller.controller.panel_type in info["panels"]:
+                    entity = EnvisalinkAttributeBinarySensor(
+                        hass,
+                        "zone",
+                        attr,
+                        zone_num,
+                        zone_entry,
+                        controller,
+                    )
+                    entities.append(entity)
+
+    # Setup partition sensors
+    partition_spec: str = entry.data.get(CONF_PARTITION_SET, "")
+    partition_set = parse_range_string(
+        partition_spec, min_val=1, max_val=controller.controller.max_partitions
+    )
+    partition_info = entry.data.get(CONF_PARTITIONS)
+    if partition_set is not None:
+        for part_num in partition_set:
+            part_entry = find_yaml_info(part_num, partition_info)
+
+            # Create sensors to reflect attributes tracked by pyenvisalink
+            for attr, info in _attribute_sensor_info["partition"].items():
+                if controller.controller.panel_type in info["panels"]:
+                    entity = EnvisalinkAttributeBinarySensor(
+                        hass,
+                        "partition",
+                        attr,
+                        part_num,
+                        part_entry,
+                        controller,
+                    )
+                    entities.append(entity)
+
+    async_add_entities(entities)
 
 
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity, RestoreEntity):
@@ -125,3 +221,51 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity, RestoreEntity
     def device_class(self):
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return self._zone_type
+
+
+class EnvisalinkAttributeBinarySensor(EnvisalinkDevice, BinarySensorEntity):
+    """Representation of an Envisalink binary sensor."""
+
+    def __init__(self, hass, attr_type, evl_attr_name, index, extra_yaml_conf, controller):
+        """Initialize the sensor."""
+
+        sensor_info = _attribute_sensor_info[attr_type]
+
+        self._icon = sensor_info[evl_attr_name]["icon"]
+        self._attr_device_class = sensor_info[evl_attr_name]["device_class"]
+        self._evl_attr_type = attr_type
+        self._evl_attr_name = evl_attr_name
+        self._index = index
+
+        setup_info = generate_entity_setup_info(
+            controller,
+            attr_type,
+            index,
+            sensor_info[evl_attr_name]["name"],
+            extra_yaml_conf,
+        )
+        name = setup_info["name"]
+        self._attr_unique_id = setup_info["unique_id"]
+        self._attr_has_entity_name = setup_info["has_entity_name"]
+
+        LOGGER.debug("Setting up binary_sensor: %s", name)
+        super().__init__(
+            name,
+            controller,
+            STATE_CHANGE_PARTITION if attr_type == "partition" else STATE_CHANGE_ZONE,
+            index,
+        )
+
+    @property
+    def _info(self):
+        return self._controller.controller.alarm_state[self._evl_attr_type][self._index]
+
+    @property
+    def icon(self):
+        """Return the icon if any."""
+        return self._icon
+
+    @property
+    def is_on(self):
+        """Return true if sensor is on."""
+        return self._info["status"].get(self._evl_attr_name)

--- a/custom_components/envisalink_new/binary_sensor.py
+++ b/custom_components/envisalink_new/binary_sensor.py
@@ -20,7 +20,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .helpers import find_yaml_info, parse_range_string
+from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
 from .models import EnvisalinkDevice
 from .pyenvisalink.const import STATE_CHANGE_ZONE
 
@@ -58,21 +58,18 @@ async def async_setup_entry(
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity, RestoreEntity):
     """Representation of an Envisalink binary sensor."""
 
-    def __init__(self, hass, zone_number, zone_info, controller):
+    def __init__(self, hass, zone_number, zone_conf, controller):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
-        name = f"Zone {self._zone_number}"
-        self._attr_unique_id = f"{controller.unique_id}_{name}"
 
-        self._zone_type = DEFAULT_ZONETYPE
+        setup_info = generate_entity_setup_info(
+            controller, "zone", zone_number, None, zone_conf
+        )
 
-        self._attr_has_entity_name = True
-        if zone_info:
-            # Override the name and type if there is info from the YAML configuration
-            self._zone_type = zone_info.get(CONF_ZONETYPE, DEFAULT_ZONETYPE)
-            if CONF_ZONENAME in zone_info:
-                name = zone_info[CONF_ZONENAME]
-                self._attr_has_entity_name = False
+        name = setup_info["name"]
+        self._attr_unique_id = setup_info["unique_id"]
+        self._zone_type = setup_info["zone_type"]
+        self._attr_has_entity_name = setup_info["has_entity_name"]
 
         LOGGER.debug("Setting up zone: %s", name)
         super().__init__(name, controller, STATE_CHANGE_ZONE, zone_number)

--- a/custom_components/envisalink_new/const.py
+++ b/custom_components/envisalink_new/const.py
@@ -23,6 +23,7 @@ CONF_USERNAME = "user_name"
 CONF_ZONEDUMP_INTERVAL = "zonedump_interval"  # OPTION
 CONF_CREATE_ZONE_BYPASS_SWITCHES = "create_zone_bypass_switches"  # OPTION
 CONF_HONEYWELL_ARM_NIGHT_MODE = "honeywell_arm_night_mode"  # OPTION
+CONF_WIRELESS_ZONE_SET = "wireless_zone_set"
 
 
 # Config items used only in the YAML config

--- a/custom_components/envisalink_new/helpers.py
+++ b/custom_components/envisalink_new/helpers.py
@@ -1,5 +1,7 @@
 """Helper functions for the Envisalink integration."""
 
+from .const import CONF_PARTITIONNAME, CONF_ZONENAME, CONF_ZONETYPE, DEFAULT_ZONETYPE
+
 
 def find_yaml_info(entry_number: int, info) -> map | None:
     """Locate the given entry from a dict whose keys may be strings."""
@@ -86,3 +88,33 @@ def extract_discovery_endpoint(discovery_port) -> tuple:
         return (None, int(hostAndPort[0]))
 
     return (":".join(hostAndPort[0:-1]), int(hostAndPort[-1]))
+
+
+def generate_entity_setup_info(
+    controller, entity_type: str, index: int, suffix: str, extra_yaml_conf: dict
+) -> dict:
+    if not suffix:
+        suffix = ""
+    else:
+        suffix = " " + suffix
+
+    name = f"{entity_type.title()} {index}{suffix}"
+    unique_id = f"{controller.unique_id}_{name}"
+
+    zone_type = DEFAULT_ZONETYPE
+    has_entity_name = True
+    if extra_yaml_conf:
+        # Override the name if there is info from the YAML configuration
+        name_key = CONF_ZONENAME if entity_type == "zone" else CONF_PARTITIONNAME
+        if name_key in extra_yaml_conf:
+            name = f"{extra_yaml_conf[name_key]}{suffix}"
+            has_entity_name = False
+
+        zone_type = extra_yaml_conf.get(CONF_ZONETYPE, DEFAULT_ZONETYPE)
+
+    return {
+        "name": name,
+        "unique_id": unique_id,
+        "has_entity_name": has_entity_name,
+        "zone_type": zone_type,
+    }

--- a/custom_components/envisalink_new/sensor.py
+++ b/custom_components/envisalink_new/sensor.py
@@ -1,10 +1,9 @@
 """Support for Envisalink sensors (shows panel info)."""
 from __future__ import annotations
 
-from .pyenvisalink.const import STATE_CHANGE_PARTITION
-
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -12,11 +11,61 @@ from .const import (
     CONF_PARTITION_SET,
     CONF_PARTITIONNAME,
     CONF_PARTITIONS,
+    CONF_ZONE_SET,
+    CONF_ZONES,
     DOMAIN,
     LOGGER,
 )
-from .helpers import find_yaml_info, parse_range_string
+from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
 from .models import EnvisalinkDevice
+from .pyenvisalink.const import (
+    PANEL_TYPE_DSC,
+    PANEL_TYPE_HONEYWELL,
+    STATE_CHANGE_PARTITION,
+    STATE_CHANGE_ZONE,
+)
+
+_attribute_sensor_info = {
+    "partition": {
+        "ac_present": {
+            "name": "AC Present",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:power-plug",
+        },
+        "ready": {
+            "name": "Ready",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:check",
+        },
+        "bat_trouble": {
+            "name": "Battery Trouble",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:battery-alert",
+        },
+        "trouble": {
+            "name": "Trouble",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:alert",
+        },
+        "fire": {
+            "name": "Fire",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:fire",
+        },
+        "alarm": {
+            "name": "Alarm",
+            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
+            "icon": "mdi:alarm-light",
+        },
+    },
+    "zone": {
+        "low_battery": {
+            "name": "Low Battery",
+            "panels": [PANEL_TYPE_DSC],
+            "icon": "mdi:battery-alert",
+        },
+    },
+}
 
 
 async def async_setup_entry(
@@ -27,17 +76,19 @@ async def async_setup_entry(
     """Set up the alarm keypad entity based on a config entry."""
     controller = hass.data[DOMAIN][entry.entry_id]
 
+    entities = []
+
+    # Setup partition sensors
     partition_spec: str = entry.data.get(CONF_PARTITION_SET, "")
     partition_set = parse_range_string(
         partition_spec, min_val=1, max_val=controller.controller.max_partitions
     )
     partition_info = entry.data.get(CONF_PARTITIONS)
     if partition_set is not None:
-        entities = []
         for part_num in partition_set:
             part_entry = find_yaml_info(part_num, partition_info)
 
-            entity = EnvisalinkSensor(
+            entity = EnvisalinkKeypadSensor(
                 hass,
                 part_num,
                 part_entry,
@@ -45,15 +96,52 @@ async def async_setup_entry(
             )
             entities.append(entity)
 
+            # Create additional sensors to reflect attributes tracked by pyenvisalink
+            for attr, info in _attribute_sensor_info["partition"].items():
+                if controller.controller.panel_type in info["panels"]:
+                    entity = EnvisalinkAttributeSensor(
+                        hass,
+                        "partition",
+                        attr,
+                        part_num,
+                        part_entry,
+                        controller,
+                    )
+                    entities.append(entity)
+
+    # Setup zone sensors
+    zone_spec: str = entry.data.get(CONF_ZONE_SET, "")
+    zone_set = parse_range_string(
+        zone_spec, min_val=1, max_val=controller.controller.max_zones
+    )
+
+    zone_info = entry.data.get(CONF_ZONES)
+    if zone_set is not None:
+        for zone_num in zone_set:
+            zone_entry = find_yaml_info(zone_num, zone_info)
+
+            for attr, info in _attribute_sensor_info["zone"].items():
+                if controller.controller.panel_type in info["panels"]:
+                    entity = EnvisalinkAttributeSensor(
+                        hass,
+                        "zone",
+                        attr,
+                        zone_num,
+                        zone_entry,
+                        controller,
+                    )
+                    entities.append(entity)
+
+    if entities:
         async_add_entities(entities)
 
 
-class EnvisalinkSensor(EnvisalinkDevice, SensorEntity):
+class EnvisalinkKeypadSensor(EnvisalinkDevice, SensorEntity):
     """Representation of an Envisalink keypad."""
 
     def __init__(self, hass, partition_number, partition_info, controller):
         """Initialize the sensor."""
-        self._icon = "mdi:alarm"
+        self._icon = "mdi:alarm-panel"
         self._partition_number = partition_number
         name = f"Partition {partition_number} Keypad"
         self._attr_unique_id = f"{controller.unique_id}_{name}"
@@ -70,9 +158,7 @@ class EnvisalinkSensor(EnvisalinkDevice, SensorEntity):
 
     @property
     def _info(self):
-        return self._controller.controller.alarm_state["partition"][
-            self._partition_number
-        ]
+        return self._controller.controller.alarm_state["partition"][self._partition_number]
 
     @property
     def icon(self):
@@ -88,3 +174,50 @@ class EnvisalinkSensor(EnvisalinkDevice, SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes."""
         return self._info["status"]
+
+
+class EnvisalinkAttributeSensor(EnvisalinkDevice, SensorEntity):
+    """Representation of an Envisalink keypad."""
+
+    def __init__(self, hass, attr_type, evl_attr_name, index, extra_yaml_conf, controller):
+        """Initialize the sensor."""
+
+        sensor_info = _attribute_sensor_info[attr_type]
+
+        self._icon = sensor_info[evl_attr_name]["icon"]
+        self._evl_attr_type = attr_type
+        self._evl_attr_name = evl_attr_name
+        self._index = index
+
+        setup_info = generate_entity_setup_info(
+            controller,
+            attr_type,
+            index,
+            sensor_info[evl_attr_name]["name"],
+            extra_yaml_conf,
+        )
+        name = setup_info["name"]
+        self._attr_unique_id = setup_info["unique_id"]
+        self._attr_has_entity_name = setup_info["has_entity_name"]
+
+        LOGGER.debug("Setting up sensor: %s", name)
+        super().__init__(
+            name,
+            controller,
+            STATE_CHANGE_PARTITION if attr_type == "partition" else STATE_CHANGE_ZONE,
+            index,
+        )
+
+    @property
+    def _info(self):
+        return self._controller.controller.alarm_state[self._evl_attr_type][self._index]
+
+    @property
+    def icon(self):
+        """Return the icon if any."""
+        return self._icon
+
+    @property
+    def native_value(self):
+        """Return the status field that represents the sensor state."""
+        return self._info["status"].get(self._evl_attr_name, STATE_UNKNOWN)

--- a/custom_components/envisalink_new/sensor.py
+++ b/custom_components/envisalink_new/sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -11,61 +10,12 @@ from .const import (
     CONF_PARTITION_SET,
     CONF_PARTITIONNAME,
     CONF_PARTITIONS,
-    CONF_ZONE_SET,
-    CONF_ZONES,
     DOMAIN,
     LOGGER,
 )
 from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
 from .models import EnvisalinkDevice
-from .pyenvisalink.const import (
-    PANEL_TYPE_DSC,
-    PANEL_TYPE_HONEYWELL,
-    STATE_CHANGE_PARTITION,
-    STATE_CHANGE_ZONE,
-)
-
-_attribute_sensor_info = {
-    "partition": {
-        "ac_present": {
-            "name": "AC Present",
-            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
-            "icon": "mdi:power-plug",
-        },
-        "ready": {
-            "name": "Ready",
-            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
-            "icon": "mdi:check",
-        },
-        "bat_trouble": {
-            "name": "Battery Trouble",
-            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
-            "icon": "mdi:battery-alert",
-        },
-        "trouble": {
-            "name": "Trouble",
-            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
-            "icon": "mdi:alert",
-        },
-        "fire": {
-            "name": "Fire",
-            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
-            "icon": "mdi:fire",
-        },
-        "alarm": {
-            "name": "Alarm",
-            "panels": [PANEL_TYPE_DSC, PANEL_TYPE_HONEYWELL],
-            "icon": "mdi:alarm-light",
-        },
-    },
-    "zone": {
-        "low_battery": {
-            "name": "Low Battery",
-            "panels": [PANEL_TYPE_DSC],
-            "icon": "mdi:battery-alert",
-        },
-    },
-}
+from .pyenvisalink.const import STATE_CHANGE_PARTITION
 
 
 async def async_setup_entry(
@@ -95,42 +45,6 @@ async def async_setup_entry(
                 controller,
             )
             entities.append(entity)
-
-            # Create additional sensors to reflect attributes tracked by pyenvisalink
-            for attr, info in _attribute_sensor_info["partition"].items():
-                if controller.controller.panel_type in info["panels"]:
-                    entity = EnvisalinkAttributeSensor(
-                        hass,
-                        "partition",
-                        attr,
-                        part_num,
-                        part_entry,
-                        controller,
-                    )
-                    entities.append(entity)
-
-    # Setup zone sensors
-    zone_spec: str = entry.data.get(CONF_ZONE_SET, "")
-    zone_set = parse_range_string(
-        zone_spec, min_val=1, max_val=controller.controller.max_zones
-    )
-
-    zone_info = entry.data.get(CONF_ZONES)
-    if zone_set is not None:
-        for zone_num in zone_set:
-            zone_entry = find_yaml_info(zone_num, zone_info)
-
-            for attr, info in _attribute_sensor_info["zone"].items():
-                if controller.controller.panel_type in info["panels"]:
-                    entity = EnvisalinkAttributeSensor(
-                        hass,
-                        "zone",
-                        attr,
-                        zone_num,
-                        zone_entry,
-                        controller,
-                    )
-                    entities.append(entity)
 
     if entities:
         async_add_entities(entities)
@@ -174,50 +88,3 @@ class EnvisalinkKeypadSensor(EnvisalinkDevice, SensorEntity):
     def extra_state_attributes(self):
         """Return the state attributes."""
         return self._info["status"]
-
-
-class EnvisalinkAttributeSensor(EnvisalinkDevice, SensorEntity):
-    """Representation of an Envisalink keypad."""
-
-    def __init__(self, hass, attr_type, evl_attr_name, index, extra_yaml_conf, controller):
-        """Initialize the sensor."""
-
-        sensor_info = _attribute_sensor_info[attr_type]
-
-        self._icon = sensor_info[evl_attr_name]["icon"]
-        self._evl_attr_type = attr_type
-        self._evl_attr_name = evl_attr_name
-        self._index = index
-
-        setup_info = generate_entity_setup_info(
-            controller,
-            attr_type,
-            index,
-            sensor_info[evl_attr_name]["name"],
-            extra_yaml_conf,
-        )
-        name = setup_info["name"]
-        self._attr_unique_id = setup_info["unique_id"]
-        self._attr_has_entity_name = setup_info["has_entity_name"]
-
-        LOGGER.debug("Setting up sensor: %s", name)
-        super().__init__(
-            name,
-            controller,
-            STATE_CHANGE_PARTITION if attr_type == "partition" else STATE_CHANGE_ZONE,
-            index,
-        )
-
-    @property
-    def _info(self):
-        return self._controller.controller.alarm_state[self._evl_attr_type][self._index]
-
-    @property
-    def icon(self):
-        """Return the icon if any."""
-        return self._icon
-
-    @property
-    def native_value(self):
-        """Return the status field that represents the sensor state."""
-        return self._info["status"].get(self._evl_attr_name, STATE_UNKNOWN)

--- a/custom_components/envisalink_new/strings.json
+++ b/custom_components/envisalink_new/strings.json
@@ -53,7 +53,8 @@
           "zonedump_interval": "Zone dump interval",
           "timeout": "Connection timeout",
           "create_zone_bypass_switches": "Create zone bypass switches",
-          "honeywell_arm_night_mode": "Arm Night Mode"
+          "honeywell_arm_night_mode": "Arm Night Mode",
+          "wireless_zone_set": "Wireless Zones"
         }
       }
     },
@@ -62,6 +63,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "invalid_zone_spec": "Invalid zone specification",
       "invalid_partition_spec": "Invalid partition specification",
+      "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -1,68 +1,68 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "invalid_partition_spec": "Invalid partition specification",
-            "invalid_zone_spec": "invalid zone specification",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "alarm_name": "Alarm Name",
-                    "code": "Alarm code",
-                    "discovery_port": "Discovery Port",
-                    "host": "Host",
-                    "partition_set": "Partition list",
-                    "password": "Password",
-                    "port": "Port",
-                    "user_name": "Username",
-                    "zone_set": "Zone list"
-                }
-            }
-        }
+  "config": {
+    "abort": {
+      "already_configured": "Device is already configured"
     },
-    "options": {
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "invalid_partition_spec": "Invalid partition specification",
-            "invalid_zone_spec": "Invalid zone specification",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "advanced": {
-                "data": {
-                    "create_zone_bypass_switches": "Create zone bypass switches",
-                    "honeywell_arm_night_mode": "Arm Night Mode",
-                    "keepalive_interval": "Keep-alive interval",
-                    "panic_type": "Panic type",
-                    "timeout": "Connection timeout",
-                    "zonedump_interval": "Zone dump interval"
-                }
-            },
-            "basic": {
-                "data": {
-                    "code": "Alarm code",
-                    "discovery_port": "Discovery Port",
-                    "host": "Host",
-                    "partition_set": "Partition list",
-                    "password": "Password",
-                    "port": "Port",
-                    "user_name": "Username",
-                    "zone_set": "Zone list"
-                }
-            },
-            "init": {
-                "data": {
-                    "Advanced": "Advanced",
-                    "Basic": "Basic"
-                }
-            }
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_partition_spec": "Invalid partition specification",
+      "invalid_zone_spec": "invalid zone specification",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "alarm_name": "Alarm Name",
+          "code": "Alarm code",
+          "discovery_port": "Discovery Port",
+          "host": "Host",
+          "partition_set": "Partition list",
+          "password": "Password",
+          "port": "Port",
+          "user_name": "Username",
+          "zone_set": "Zone list"
         }
+      }
     }
+  },
+  "options": {
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_partition_spec": "Invalid partition specification",
+      "invalid_zone_spec": "Invalid zone specification",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "advanced": {
+        "data": {
+          "create_zone_bypass_switches": "Create zone bypass switches",
+          "honeywell_arm_night_mode": "Arm Night Mode",
+          "keepalive_interval": "Keep-alive interval",
+          "panic_type": "Panic type",
+          "timeout": "Connection timeout",
+          "zonedump_interval": "Zone dump interval"
+        }
+      },
+      "basic": {
+        "data": {
+          "code": "Alarm code",
+          "discovery_port": "Discovery Port",
+          "host": "Host",
+          "partition_set": "Partition list",
+          "password": "Password",
+          "port": "Port",
+          "user_name": "Username",
+          "zone_set": "Zone list"
+        }
+      },
+      "init": {
+        "data": {
+          "Advanced": "Advanced",
+          "Basic": "Basic"
+        }
+      }
+    }
+  }
 }

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -7,7 +7,8 @@
       "cannot_connect": "Failed to connect",
       "invalid_auth": "Invalid authentication",
       "invalid_partition_spec": "Invalid partition specification",
-      "invalid_zone_spec": "invalid zone specification",
+      "invalid_zone_spec": "Invalid zone specification",
+      "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
       "unknown": "Unexpected error"
     },
     "step": {
@@ -32,6 +33,7 @@
       "invalid_auth": "Invalid authentication",
       "invalid_partition_spec": "Invalid partition specification",
       "invalid_zone_spec": "Invalid zone specification",
+      "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
       "unknown": "Unexpected error"
     },
     "step": {
@@ -42,7 +44,8 @@
           "keepalive_interval": "Keep-alive interval",
           "panic_type": "Panic type",
           "timeout": "Connection timeout",
-          "zonedump_interval": "Zone dump interval"
+          "zonedump_interval": "Zone dump interval",
+          "wireless_zone_set": "Wireless Zones"
         }
       },
       "basic": {


### PR DESCRIPTION
New binary sensors for the panel representing:
* AC Present
* Ready to arm
* Panel Battery
* Panel Health (Trouble)
* Fire
* Alarm

New binary sensors for each zone representing:
* Fault
* Low battery on wireless sensor (DSC only).  To enable low battery entities, the list of "wireless" zones must be specified in the `Advanced` settings.

Related issues:
* #17
* #63
* #85

