### PR TITLE
Changed Panic Type plain-text field to a selector drop-down in the advanced config_flow

### DIFF
--- a/custom_components/envisalink_new/config_flow.py
+++ b/custom_components/envisalink_new/config_flow.py
@@ -180,7 +180,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Optional(
                 CONF_PANIC,
                 default=self.config_entry.options.get(CONF_PANIC, DEFAULT_PANIC),
-            ): cv.string,
+            ): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["Fire", "Ambulance", "Police"],
+                    mode=selector.SelectSelectorMode.DROPDOWN,
+                    translation_key="panic_type",
+                ),
+            ),
             vol.Optional(
                 CONF_EVL_KEEPALIVE,
                 default=self.config_entry.options.get(

--- a/custom_components/envisalink_new/strings.json
+++ b/custom_components/envisalink_new/strings.json
@@ -66,5 +66,14 @@
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
+  },
+  "selector": {
+    "panic_type": {
+      "options": {
+        "Fire": "Fire",
+        "Ambulance": "Ambulance",
+        "Police": "Police"
+      }
+    }
   }
 }

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -67,5 +67,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "panic_type": {
+      "options": {
+        "Fire": "Fire",
+        "Ambulance": "Ambulance",
+        "Police": "Police"
+      }
+    }
   }
 }

--- a/custom_components/envisalink_new/translations/fr.json
+++ b/custom_components/envisalink_new/translations/fr.json
@@ -69,5 +69,14 @@
         }
       }
     }
+  },
+  "selector": {
+    "panic_type": {
+      "options": {
+        "Fire": "Incendie",
+        "Ambulance": "Ambulance",
+        "Police": "Police"
+      }
+    }
   }
 }


### PR DESCRIPTION
The selector fields are common to Honeywell and DSC. I did not know what was this option, with a drop-down it's much more clear IMO.