### PR TITLE
Add ability to assign zones to their respective partitions

### DIFF
--- a/custom_components/envisalink_new/binary_sensor.py
+++ b/custom_components/envisalink_new/binary_sensor.py
@@ -125,7 +125,7 @@ async def async_setup_entry(
     )
 
     zone_to_partition_map = build_zone_to_partition_map(
-        entry, controller.controller.max_zones
+        entry, controller.controller.max_zones, controller.controller.max_partitions
     )
 
     zone_info = entry.data.get(CONF_ZONES)

--- a/custom_components/envisalink_new/binary_sensor.py
+++ b/custom_components/envisalink_new/binary_sensor.py
@@ -27,7 +27,12 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
+from .helpers import (
+    build_zone_to_partition_map,
+    find_yaml_info,
+    generate_entity_setup_info,
+    parse_range_string,
+)
 from .models import EnvisalinkDevice
 from .pyenvisalink.const import (
     PANEL_TYPE_DSC,
@@ -119,15 +124,21 @@ async def async_setup_entry(
         zone_spec, min_val=1, max_val=controller.controller.max_zones
     )
 
+    zone_to_partition_map = build_zone_to_partition_map(
+        entry, controller.controller.max_zones
+    )
+
     zone_info = entry.data.get(CONF_ZONES)
     if zone_set is not None:
         for zone_num in zone_set:
             zone_entry = find_yaml_info(zone_num, zone_info)
 
+            partition = zone_to_partition_map[zone_num]
             entity = EnvisalinkBinarySensor(
                 hass,
                 zone_num,
                 zone_entry,
+                partition,
                 controller,
             )
             entities.append(entity)
@@ -151,6 +162,7 @@ async def async_setup_entry(
                             zone_num,
                             zone_entry,
                             controller,
+                            partition,
                         )
                         entities.append(entity)
 
@@ -183,9 +195,10 @@ async def async_setup_entry(
 class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity, RestoreEntity):
     """Representation of an Envisalink binary sensor."""
 
-    def __init__(self, hass, zone_number, zone_conf, controller):
+    def __init__(self, hass, zone_number, zone_conf, partition, controller):
         """Initialize the binary_sensor."""
         self._zone_number = zone_number
+        self._partition = partition
 
         setup_info = generate_entity_setup_info(
             controller, "zone", zone_number, None, zone_conf
@@ -228,10 +241,11 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity, RestoreEntity
                 last_fault
             ).isoformat()
 
-        # Expose the zone number as an attribute to allow
+        # Expose the zone and partition numbers as attributes to allow
         # for easier entity to zone mapping (e.g. to bypass
         # the zone).
         attr["zone"] = self._zone_number
+        attr["partition"] = self._partition
 
         # Expose whether the zone is currently bypassed
         attr["bypassed"] = self._info["bypassed"]
@@ -255,7 +269,16 @@ class EnvisalinkBinarySensor(EnvisalinkDevice, BinarySensorEntity, RestoreEntity
 class EnvisalinkAttributeBinarySensor(EnvisalinkDevice, BinarySensorEntity):
     """Representation of an Envisalink binary sensor."""
 
-    def __init__(self, hass, attr_type, evl_attr_name, index, extra_yaml_conf, controller):
+    def __init__(
+        self,
+        hass,
+        attr_type,
+        evl_attr_name,
+        index,
+        extra_yaml_conf,
+        controller,
+        partition=None,
+    ):
         """Initialize the sensor."""
 
         sensor_info = _attribute_sensor_info[attr_type]
@@ -267,6 +290,8 @@ class EnvisalinkAttributeBinarySensor(EnvisalinkDevice, BinarySensorEntity):
         self._evl_attr_type = attr_type
         self._evl_attr_name = evl_attr_name
         self._index = index
+        if partition:
+            self._partition = partition
 
         setup_info = generate_entity_setup_info(
             controller,
@@ -300,3 +325,13 @@ class EnvisalinkAttributeBinarySensor(EnvisalinkDevice, BinarySensorEntity):
     def is_on(self):
         """Return true if sensor is on."""
         return self._info["status"].get(self._evl_attr_name)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+
+        if self._evl_attr_type == "zone":
+            attr["zone"] = self._index
+            attr["partition"] = self._partition
+        return attr

--- a/custom_components/envisalink_new/config_flow.py
+++ b/custom_components/envisalink_new/config_flow.py
@@ -171,6 +171,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         if user_input is not None:
             # Make sure all the options are here
             try:
+                if CONF_PARTITION_ASSIGNMENTS in self.config_entry.options:
+                    user_input[CONF_PARTITION_ASSIGNMENTS] = self.config_entry.options.get(
+                        CONF_PARTITION_ASSIGNMENTS
+                    )
                 # Validate that the new settings are okay
                 self._validate_advanced_options(user_input)
                 return self.async_create_entry(title="", data=user_input)
@@ -280,7 +284,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             # Make sure all the options are here
             try:
                 new_options = dict(self.config_entry.options)
-                new_options["partition_assignments"] = user_input
+                new_options[CONF_PARTITION_ASSIGNMENTS] = user_input
                 # Validate that the new settings are okay
                 self._validate_advanced_options(new_options)
                 return self.async_create_entry(title="", data=new_options)

--- a/custom_components/envisalink_new/const.py
+++ b/custom_components/envisalink_new/const.py
@@ -28,6 +28,7 @@ CONF_HONEYWELL_ARM_NIGHT_MODE = "honeywell_arm_night_mode"  # OPTION
 CONF_WIRELESS_ZONE_SET = "wireless_zone_set"
 CONF_SHOW_KEYPAD = "show_keypad"
 CONF_CODE_ARM_REQUIRED = "code_arm_required"
+CONF_PARTITION_ASSIGNMENTS = "partition_assignments"
 
 
 # Config items used only in the YAML config

--- a/custom_components/envisalink_new/helpers.py
+++ b/custom_components/envisalink_new/helpers.py
@@ -1,6 +1,14 @@
 """Helper functions for the Envisalink integration."""
 
-from .const import CONF_PARTITIONNAME, CONF_ZONENAME, CONF_ZONETYPE, DEFAULT_ZONETYPE
+from homeassistant.config_entries import ConfigEntry
+
+from .const import (
+    CONF_PARTITION_ASSIGNMENTS,
+    CONF_PARTITIONNAME,
+    CONF_ZONENAME,
+    CONF_ZONETYPE,
+    DEFAULT_ZONETYPE,
+)
 
 
 def find_yaml_info(entry_number: int, info) -> map | None:
@@ -118,3 +126,20 @@ def generate_entity_setup_info(
         "has_entity_name": has_entity_name,
         "zone_type": zone_type,
     }
+
+
+def build_zone_to_partition_map(config_entry: ConfigEntry, max_zones: int) -> dict:
+    zone_map = {}
+
+    # Default all zones to partition 1
+    for zone in range(max_zones):
+        zone_map[zone + 1] = 1
+
+    partition_assignments: str = config_entry.options.get(CONF_PARTITION_ASSIGNMENTS)
+    if partition_assignments:
+        for partition, zone_set in partition_assignments.items():
+            zone_list = parse_range_string(zone_set, 1, max_zones)
+            for z in zone_list:
+                zone_map[z] = partition
+
+    return zone_map

--- a/custom_components/envisalink_new/helpers.py
+++ b/custom_components/envisalink_new/helpers.py
@@ -139,7 +139,8 @@ def build_zone_to_partition_map(config_entry: ConfigEntry, max_zones: int) -> di
     if partition_assignments:
         for partition, zone_set in partition_assignments.items():
             zone_list = parse_range_string(zone_set, 1, max_zones)
-            for z in zone_list:
-                zone_map[z] = partition
+            if zone_list:
+                for z in zone_list:
+                    zone_map[z] = partition
 
     return zone_map

--- a/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
+++ b/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
@@ -359,12 +359,12 @@ class EnvisalinkAlarmPanel:
         else:
             _LOGGER.error(COMMAND_ERR)
 
-    async def toggle_zone_bypass(self, zone):
+    async def toggle_zone_bypass(self, zone, partition):
         """Public method to toggle a zone's bypass state."""
         if not self._zoneBypassEnabled:
             _LOGGER.error(COMMAND_ERR)
         elif self._client:
-            await self._client.toggle_zone_bypass(zone)
+            await self._client.toggle_zone_bypass(zone, partition)
         else:
             _LOGGER.error(COMMAND_ERR)
 

--- a/custom_components/envisalink_new/pyenvisalink/dsc_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/dsc_client.py
@@ -94,12 +94,12 @@ class DSCClient(EnvisalinkClient):
         """Public method to raise a panic alarm."""
         await self.queue_command(evl_Commands["Panic"], evl_PanicTypes[panicType])
 
-    async def toggle_zone_bypass(self, zone):
+    async def toggle_zone_bypass(self, zone, partition):
         """Public method to toggle a zone's bypass state."""
-        await self.keypresses_to_partition(1, "*1%02d#" % zone)
+        await self.keypresses_to_partition(partition, "*1%02d#" % zone)
 
     async def toggle_chime(self, code):
-        """Public method to toggle a zone's bypass state."""
+        """Public method to toggle the door chime."""
         await self.keypresses_to_partition(1, '*4')
 
     async def command_output(self, code, partitionNumber, outputNumber):

--- a/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
@@ -283,7 +283,7 @@ class EnvisalinkClient:
         """Public method to trigger the panic alarm."""
         raise NotImplementedError()
 
-    async def toggle_zone_bypass(self, zone):
+    async def toggle_zone_bypass(self, zone, partition):
         """Public method to toggle a zone's bypass state."""
         raise NotImplementedError()
 

--- a/custom_components/envisalink_new/sensor.py
+++ b/custom_components/envisalink_new/sensor.py
@@ -13,7 +13,7 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
+from .helpers import find_yaml_info, parse_range_string
 from .models import EnvisalinkDevice
 from .pyenvisalink.const import STATE_CHANGE_PARTITION
 

--- a/custom_components/envisalink_new/strings.json
+++ b/custom_components/envisalink_new/strings.json
@@ -31,7 +31,8 @@
       "init": {
         "menu_options": {
           "basic": "Basic",
-          "advanced": "Advanced"
+          "advanced": "Advanced",
+          "partition_assignments": "Partition Assignments"
         }
       },
       "basic": {
@@ -58,6 +59,20 @@
           "show_keypad": "Show keypad",
           "code_arm_required": "Code required to arm"
         }
+      },
+      "partition_assignments": {
+        "name": "Partition Assignments",
+        "description": "List of zones assigned to each partition",
+        "data": {
+          "1": "Partition 1",
+          "2": "Partition 2",
+          "3": "Partition 3",
+          "4": "Partition 4",
+          "5": "Partition 5",
+          "6": "Partition 6",
+          "7": "Partition 7",
+          "8": "Partition 8"
+        }
       }
     },
     "error": {
@@ -66,7 +81,8 @@
       "invalid_zone_spec": "Invalid zone specification",
       "invalid_partition_spec": "Invalid partition specification",
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown_zones": "Zone(s) specified do not exist in main zone list"
     }
   },
   "selector": {

--- a/custom_components/envisalink_new/strings.json
+++ b/custom_components/envisalink_new/strings.json
@@ -82,7 +82,8 @@
       "invalid_partition_spec": "Invalid partition specification",
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "unknown_zones": "Zone(s) specified do not exist in main zone list"
+      "unknown_zones": "Zone(s) specified do not exist in main zone list",
+      "zone_already_in_partition": "Zone assigned to multiple partitions"
     }
   },
   "selector": {

--- a/custom_components/envisalink_new/switch.py
+++ b/custom_components/envisalink_new/switch.py
@@ -58,7 +58,7 @@ async def async_setup_entry(
         )
         zone_info = entry.data.get(CONF_ZONES)
         zone_to_partition_map = build_zone_to_partition_map(
-            entry, controller.controller.max_zones
+            entry, controller.controller.max_zones, controller.controller.max_partitions
         )
         if zone_set is not None:
             for zone_num in zone_set:

--- a/custom_components/envisalink_new/switch.py
+++ b/custom_components/envisalink_new/switch.py
@@ -19,7 +19,12 @@ from .const import (
     DOMAIN,
     LOGGER,
 )
-from .helpers import find_yaml_info, generate_entity_setup_info, parse_range_string
+from .helpers import (
+    build_zone_to_partition_map,
+    find_yaml_info,
+    generate_entity_setup_info,
+    parse_range_string,
+)
 from .models import EnvisalinkDevice
 from .pyenvisalink.const import (
     PANEL_TYPE_DSC,
@@ -52,6 +57,9 @@ async def async_setup_entry(
             zone_spec, min_val=1, max_val=controller.controller.max_zones
         )
         zone_info = entry.data.get(CONF_ZONES)
+        zone_to_partition_map = build_zone_to_partition_map(
+            entry, controller.controller.max_zones
+        )
         if zone_set is not None:
             for zone_num in zone_set:
                 zone_entry = find_yaml_info(zone_num, zone_info)
@@ -61,6 +69,7 @@ async def async_setup_entry(
                     zone_num,
                     zone_entry,
                     controller,
+                    zone_to_partition_map[zone_num],
                 )
                 entities.append(entity)
 
@@ -70,9 +79,10 @@ async def async_setup_entry(
 class EnvisalinkBypassSwitch(EnvisalinkDevice, SwitchEntity):
     """Representation of an Envisalink bypass switch."""
 
-    def __init__(self, hass, zone_number, zone_conf, controller):
+    def __init__(self, hass, zone_number, zone_conf, controller, partition):
         """Initialize the switch."""
         self._zone_number = zone_number
+        self._partition = partition
 
         setup_info = generate_entity_setup_info(
             controller, "zone", zone_number, "Bypass", zone_conf
@@ -102,6 +112,15 @@ class EnvisalinkBypassSwitch(EnvisalinkDevice, SwitchEntity):
     async def async_turn_off(self, **kwargs):
         """Send the bypass keypress sequence to toggle the zone bypass."""
         await self._controller.controller.toggle_zone_bypass(self._zone_number)
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes."""
+        attr = {}
+
+        attr["zone"] = self._zone_number
+        attr["partition"] = self._partition
+        return attr
 
 
 class EnvisalinkChimeSwitch(EnvisalinkDevice, SwitchEntity, RestoreEntity):

--- a/custom_components/envisalink_new/switch.py
+++ b/custom_components/envisalink_new/switch.py
@@ -107,11 +107,15 @@ class EnvisalinkBypassSwitch(EnvisalinkDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Send the bypass keypress sequence to toggle the zone bypass."""
-        await self._controller.controller.toggle_zone_bypass(self._zone_number)
+        await self._controller.controller.toggle_zone_bypass(
+            self._zone_number, self._partition
+        )
 
     async def async_turn_off(self, **kwargs):
         """Send the bypass keypress sequence to toggle the zone bypass."""
-        await self._controller.controller.toggle_zone_bypass(self._zone_number)
+        await self._controller.controller.toggle_zone_bypass(
+            self._zone_number, self._partition
+        )
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -1,67 +1,63 @@
 {
   "config": {
-    "abort": {
-      "already_configured": "Device is already configured"
-    },
-    "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "invalid_partition_spec": "Invalid partition specification",
-      "invalid_zone_spec": "Invalid zone specification",
-      "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
-      "unknown": "Unexpected error",
-      "unknown_zones": "Zone(s) specified do not exist in main zone list"
-    },
     "step": {
       "user": {
         "data": {
           "alarm_name": "Alarm Name",
-          "code": "Alarm code",
-          "discovery_port": "Discovery Port",
-          "host": "Host",
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "user_name": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
           "partition_set": "Partition list",
-          "password": "Password",
-          "port": "Port",
-          "user_name": "Username",
-          "zone_set": "Zone list"
+          "zone_set": "Zone list",
+          "code": "Alarm code",
+          "discovery_port": "Discovery Port"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_zone_spec": "invalid zone specification",
+      "invalid_partition_spec": "Invalid partition specification",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "options": {
-    "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "invalid_partition_spec": "Invalid partition specification",
-      "invalid_zone_spec": "Invalid zone specification",
-      "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
-      "unknown": "Unexpected error",
-      "unknown_zones": "Zone(s) specified do not exist in main zone list"
-    },
     "step": {
-      "advanced": {
-        "data": {
-          "create_zone_bypass_switches": "Create zone bypass switches",
-          "honeywell_arm_night_mode": "Arm Night Mode",
-          "keepalive_interval": "Keep-alive interval",
-          "panic_type": "Panic type",
-          "timeout": "Connection timeout",
-          "zonedump_interval": "Zone dump interval",
-          "wireless_zone_set": "Wireless Zones",
-          "show_keypad": "Show keypad",
-          "code_arm_required": "Code required to arm"
+      "init": {
+        "menu_options": {
+          "basic": "Basic",
+          "advanced": "Advanced",
+          "partition_assignments": "Partition Assignments"
         }
       },
       "basic": {
         "data": {
-          "code": "Alarm code",
-          "discovery_port": "Discovery Port",
-          "host": "Host",
-          "partition_set": "Partition list",
-          "password": "Password",
-          "port": "Port",
-          "user_name": "Username",
-          "zone_set": "Zone list"
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "user_name": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "partition_set": "[%key:component::envisalink::config::step::user::data::partition_set%]",
+          "zone_set": "[%key:component::envisalink::config::step::user::data::zone_set%]",
+          "code": "[%key:component::envisalink::config::step::user::data::code%]",
+          "discovery_port": "[%key:component::envisalink::config::step::user::data::discovery_port%]"
+        }
+      },
+      "advanced": {
+        "data": {
+          "panic_type": "Panic type",
+          "keepalive_interval": "Keep-alive interval",
+          "zonedump_interval": "Zone dump interval",
+          "timeout": "Connection timeout",
+          "create_zone_bypass_switches": "Create zone bypass switches",
+          "honeywell_arm_night_mode": "Arm Night Mode",
+          "wireless_zone_set": "Wireless Zones",
+          "show_keypad": "Show keypad",
+          "code_arm_required": "Code required to arm"
         }
       },
       "partition_assignments": {
@@ -77,14 +73,16 @@
           "7": "Partition 7",
           "8": "Partition 8"
         }
-      },
-      "init": {
-        "menu_options": {
-          "advanced": "Advanced",
-          "basic": "Basic",
-          "partition_assignments": "Partition Assignments"
-        }
       }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "invalid_zone_spec": "Invalid zone specification",
+      "invalid_partition_spec": "Invalid partition specification",
+      "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown_zones": "Zone(s) specified do not exist in main zone list"
     }
   },
   "selector": {

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -82,7 +82,8 @@
       "invalid_partition_spec": "Invalid partition specification",
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
       "unknown": "Unexpected error",
-      "unknown_zones": "Zone(s) specified do not exist in main zone list"
+      "unknown_zones": "Zone(s) specified do not exist in main zone list",
+      "zone_already_in_partition": "Zone assigned to multiple partitions"
     }
   },
   "selector": {

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -9,7 +9,8 @@
       "invalid_partition_spec": "Invalid partition specification",
       "invalid_zone_spec": "Invalid zone specification",
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "unknown_zones": "Zone(s) specified do not exist in main zone list"
     },
     "step": {
       "user": {
@@ -34,7 +35,8 @@
       "invalid_partition_spec": "Invalid partition specification",
       "invalid_zone_spec": "Invalid zone specification",
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
-      "unknown": "Unexpected error"
+      "unknown": "Unexpected error",
+      "unknown_zones": "Zone(s) specified do not exist in main zone list"
     },
     "step": {
       "advanced": {
@@ -62,10 +64,25 @@
           "zone_set": "Zone list"
         }
       },
+      "partition_assignments": {
+        "name": "Partition Assignments",
+        "description": "List of zones assigned to each partition",
+        "data": {
+          "1": "Partition 1",
+          "2": "Partition 2",
+          "3": "Partition 3",
+          "4": "Partition 4",
+          "5": "Partition 5",
+          "6": "Partition 6",
+          "7": "Partition 7",
+          "8": "Partition 8"
+        }
+      },
       "init": {
         "menu_options": {
           "advanced": "Advanced",
-          "basic": "Basic"
+          "basic": "Basic",
+          "partition_assignments": "Partition Assignments"
         }
       }
     }

--- a/custom_components/envisalink_new/translations/en.json
+++ b/custom_components/envisalink_new/translations/en.json
@@ -4,26 +4,26 @@
       "user": {
         "data": {
           "alarm_name": "Alarm Name",
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]",
-          "user_name": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
+          "host": "Host",
+          "port": "Port",
+          "user_name": "Username",
+          "password": "Password",
           "partition_set": "Partition list",
           "zone_set": "Zone list",
           "code": "Alarm code",
-          "discovery_port": "Discovery Port"
+          "discovery_port": "Discovery port"
         }
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_zone_spec": "invalid zone specification",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_zone_spec": "Invalid zone specification",
       "invalid_partition_spec": "Invalid partition specification",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
+      "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "Device is already configured"
     }
   },
   "options": {
@@ -37,14 +37,14 @@
       },
       "basic": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "port": "[%key:common::config_flow::data::port%]",
-          "user_name": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "partition_set": "[%key:component::envisalink::config::step::user::data::partition_set%]",
-          "zone_set": "[%key:component::envisalink::config::step::user::data::zone_set%]",
-          "code": "[%key:component::envisalink::config::step::user::data::code%]",
-          "discovery_port": "[%key:component::envisalink::config::step::user::data::discovery_port%]"
+          "host": "Host",
+          "port": "Port",
+          "user_name": "Username",
+          "password": "Password",
+          "partition_set": "Partition list",
+          "zone_set": "Zone list",
+          "code": "Alarm code",
+          "discovery_port": "Discovery port"
         }
       },
       "advanced": {
@@ -76,12 +76,12 @@
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
       "invalid_zone_spec": "Invalid zone specification",
       "invalid_partition_spec": "Invalid partition specification",
       "bad_wireless_zone": "Wireless zone(s) do not exist in main zone list",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "unknown": "Unexpected error",
       "unknown_zones": "Zone(s) specified do not exist in main zone list"
     }
   },

--- a/custom_components/envisalink_new/translations/fr.json
+++ b/custom_components/envisalink_new/translations/fr.json
@@ -82,7 +82,8 @@
       "invalid_partition_spec": "Spécification de partitions invalide",
       "bad_wireless_zone": "La zone sans-fil n'exite pas dans la liste de zones principale",
       "unknown": "Erreur inattendue",
-      "unknown_zones": "La ou les zones spécifiées n'existent pas dans la liste des zones principales"
+      "unknown_zones": "La ou les zones spécifiées n'existent pas dans la liste des zones principales",
+      "zone_already_in_partition": "La zone attribuée à plusieurs partitions"
     }
   },
   "selector": {

--- a/custom_components/envisalink_new/translations/fr.json
+++ b/custom_components/envisalink_new/translations/fr.json
@@ -1,75 +1,88 @@
 {
   "config": {
-    "abort": {
-      "already_configured": "L'appareil a déjà été configuré"
-    },
-    "error": {
-      "cannot_connect": "Impossible de se connecter",
-      "invalid_auth": "Authentification invalide",
-      "invalid_partition_spec": "Spécification de partition invalide",
-      "invalid_zone_spec": "Spécification de zone invalide",
-      "bad_wireless_zone": "La zone sans-fil n'exite pas dans la liste de zones principale",
-      "unknown": "Erreur inattendue"
-    },
     "step": {
       "user": {
         "data": {
           "alarm_name": "Nom de l'alarme",
-          "code": "Code de l'alarme",
-          "code_arm_required": "Demander un code pour armer (désactive la sortie express)",
-          "discovery_port": "Port de découverte",
           "host": "Nom de l'hôte",
-          "partition_set": "Liste de partitions",
-          "password": "Mot de passe",
           "port": "Port",
           "user_name": "Nom d'utilisateur",
-          "zone_set": "Liste de zones"
+          "password": "Mot de passe",
+          "partition_set": "Liste de partitions",
+          "zone_set": "Liste de zones",
+          "code": "Code de l'alarme",
+          "discovery_port": "Port de découverte"
         }
       }
-    }
-  },
-  "options": {
+    },
     "error": {
       "cannot_connect": "Impossible de se connecter",
       "invalid_auth": "Authentification invalide",
-      "invalid_partition_spec": "Spécification de partitions invalide",
       "invalid_zone_spec": "Spécification de zone invalide",
-      "bad_wireless_zone": "La zone sans-fil n'exite pas dans la liste de zones principale",
+      "invalid_partition_spec": "Spécification de partition invalide",
       "unknown": "Erreur inattendue"
     },
+    "abort": {
+      "already_configured": "L'appareil a déjà été configuré"
+    }
+  },
+  "options": {
     "step": {
+      "init": {
+        "menu_options": {
+          "basic": "Options de base",
+          "advanced": "Options avancées",
+          "partition_assignments": "Affectations de partition"
+        }
+      },
+      "basic": {
+        "data": {
+          "host": "Nom de l'hôte",
+          "port": "Port",
+          "user_name": "Nom d'utilisateur",
+          "password": "Mot de passe",
+          "partition_set": "Liste de partitions",
+          "zone_set": "Liste de zones",
+          "code": "Code de l'alarme",
+          "discovery_port": "Port de découverte"
+        }
+      },
       "advanced": {
         "data": {
+          "panic_type": "Type de panique",
+          "keepalive_interval": "Interval de keep-alive",
+          "zonedump_interval": "Interval de vidange de zone",
+          "timeout": "Délais d'attente pour connecter",
           "create_zone_bypass_switches": "Créer un interrupteur de bypass de zone",
           "honeywell_arm_night_mode": "Armer en mode nuit",
-          "keepalive_interval": "Interval de keep-alive",
-          "panic_type": "Type de panique",
-          "timeout": "Délais d'attente pour connecter",
-          "zonedump_interval": "Interval de vidange de zone",
           "wireless_zone_set": "Zones sans-fil",
           "show_keypad": "Afficher le clavier",
           "code_arm_required": "Demander un code pour armer"
         }
       },
-      "basic": {
+      "partition_assignments": {
+        "name": "Affectations de Partition",
+        "description": "Liste des zones affectées à chaque partition",
         "data": {
-          "code": "Code de l'alarme",
-          "code_arm_required": "Demander un code pour armer (désactive la sortie express)",
-          "discovery_port": "Port de découverte",
-          "host": "Nom de l'hôte",
-          "partition_set": "Liste de partitions",
-          "password": "Mot de passe",
-          "port": "Port",
-          "user_name": "Nom d'utilisateur",
-          "zone_set": "Liste de zones"
-        }
-      },
-      "init": {
-        "menu_options": {
-          "advanced": "Options avancées",
-          "basic": "Options de base"
+          "1": "Partition 1",
+          "2": "Partition 2",
+          "3": "Partition 3",
+          "4": "Partition 4",
+          "5": "Partition 5",
+          "6": "Partition 6",
+          "7": "Partition 7",
+          "8": "Partition 8"
         }
       }
+    },
+    "error": {
+      "cannot_connect": "Impossible de se connecter",
+      "invalid_auth": "Authentification invalide",
+      "invalid_zone_spec": "Spécification de zone invalide",
+      "invalid_partition_spec": "Spécification de partitions invalide",
+      "bad_wireless_zone": "La zone sans-fil n'exite pas dans la liste de zones principale",
+      "unknown": "Erreur inattendue",
+      "unknown_zones": "La ou les zones spécifiées n'existent pas dans la liste des zones principales"
     }
   },
   "selector": {


### PR DESCRIPTION
Add ability to assign zones to their respective partitions
* Added a new configuration page to allow the assignment of zones to their respective partitions.  
* Entities representing zones now include a `partition` attribute
* Zone bypass switches will now send the bypass command to the correct partition (DSC)