### PR TITLE
fix: allow 128 zones for UNO panels

### DIFF
--- a/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
+++ b/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
@@ -152,11 +152,9 @@ class EnvisalinkAlarmPanel:
         return EnvisalinkAlarmPanel.get_max_zones_by_version(self._evlVersion)
 
     def get_max_zones_by_version(version) -> int:
-        # UNO devices report a title of "UNO" from the web UI, and discovery stores
-        # that as version 0 rather than an EVL-style version string.
-        if version in ("4", "4MAX", 0, "0"):
-            return EVL4_MAX_ZONES
-        return EVL3_MAX_ZONES
+        if version in ("3", 3):
+            return EVL3_MAX_ZONES
+        return EVL4_MAX_ZONES
 
     def get_max_partitions() -> int:
         return MAX_PARTITIONS

--- a/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
+++ b/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
@@ -152,7 +152,9 @@ class EnvisalinkAlarmPanel:
         return EnvisalinkAlarmPanel.get_max_zones_by_version(self._evlVersion)
 
     def get_max_zones_by_version(version) -> int:
-        if version == "4" or version == "4MAX":
+        # UNO devices report a title of "UNO" from the web UI, and discovery stores
+        # that as version 0 rather than an EVL-style version string.
+        if version in ("4", "4MAX", 0, "0"):
             return EVL4_MAX_ZONES
         return EVL3_MAX_ZONES
 


### PR DESCRIPTION
## Summary

UNO devices are intentionally discovered with `evl_version = 0` by `discover_device_details()`, but `get_max_zones_by_version()` only treated `"4"` and `"4MAX"` as 128-zone devices. That caused UNO panels to fall back to the EVL3 limit of 64 zones and reject larger zone lists as invalid.

This change treats UNO's sentinel version value (`0` / `"0"`) as a 128-zone device.

## Why

On UNO hardware, discovery returns HTML with `<TITLE>UNO</TITLE>`, and the integration stores that as version `0`. The old max-zone mapping then incorrectly limited UNO users to 64 zones even when the device exposes more zones.

I confirmed this against a live UNO device:
- `/2` returned `<TITLE>UNO</TITLE>`
- `/3` returned `<TITLE>UNO</TITLE>`
- the Home Assistant config entry stored `"evl_version": 0`

## Change

- map `0` / `"0"` to `EVL4_MAX_ZONES` in `get_max_zones_by_version()`

## Validation

- confirmed the integration detects UNO devices with `evl_version = 0`
- confirmed that this `0` value currently falls into the 64-zone fallback
- verified the patch updates the max-zone mapping so UNO no longer gets capped at 64
