### PR TITLE
Network Disconnect Bug Fixes & Stability Issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.swp
 venv/
 __pycache__/
+AGENTS.md
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-*.swp
-venv/
-__pycache__/
-AGENTS.md
-

--- a/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
+++ b/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
@@ -46,7 +46,7 @@ class EnvisalinkAlarmPanel:
         keepAliveInterval=30,
         connectionTimeout=10,
         zoneBypassEnabled=False,
-        commandTimeout=5.0,
+        commandTimeout=30.0,
         httpPort=8080,
         httpHost=None,
     ):

--- a/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
+++ b/custom_components/envisalink_new/pyenvisalink/alarm_panel.py
@@ -46,7 +46,7 @@ class EnvisalinkAlarmPanel:
         keepAliveInterval=30,
         connectionTimeout=10,
         zoneBypassEnabled=False,
-        commandTimeout=30.0,
+        commandTimeout=5.0,
         httpPort=8080,
         httpHost=None,
     ):

--- a/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
@@ -121,9 +121,17 @@ class EnvisalinkClient:
                     # Connected to EVL; start reading data from the connection
                     while not self._shutdown and self._reader:
                         _LOGGER.debug("Waiting for data from EVL")
+                        # Use a short timeout during login handshake so we
+                        # detect authentication failures promptly.  Once logged
+                        # in, use a longer timeout — the EVL sends periodic
+                        # keypad updates every 5-10 s, so 30 s of silence is a
+                        # genuine anomaly worth investigating.  The shorter
+                        # timeout was causing unnecessary read-cancellation
+                        # churn during normal operation (Bug 21).
+                        read_timeout = 5 if not self._loggedin else 30
                         try:
                             chunk = await asyncio.wait_for(
-                                self._reader.read(4096), 5
+                                self._reader.read(4096), read_timeout
                             )
                         except asyncio.exceptions.TimeoutError:
                             if not self._loggedin and ((time.time() - self._connect_time) > self._alarmPanel.connection_timeout):
@@ -144,18 +152,60 @@ class EnvisalinkClient:
                                 await self.disconnect()
                             break
 
+                        if self._loggedin and self._consecutive_timeouts:
+                            _LOGGER.debug(
+                                "Received EVL data after %d consecutive command timeout(s); resetting timeout counter.",
+                                self._consecutive_timeouts,
+                            )
+                            self._consecutive_timeouts = 0
+
                         self._recv_buffer += chunk
                         self._lastReceivedTime = time.time()
                         _LOGGER.debug("RAW << %r", chunk)
 
                         # Extract and process all complete messages from the buffer.
-                        # TPI messages (Honeywell/Uno) are '$'-terminated and may arrive
-                        # without a trailing \r\n, so we process on '$' immediately rather
-                        # than waiting for a newline.  Login and DSC messages are always
-                        # '\n'-terminated without '$'.  Processing on '$' eliminates the
-                        # readuntil(\n) blocking delay that was the root cause of keepalive
-                        # timeouts (see Bug 14).
+                        #
+                        # Message framing priorities:
+                        #  1. Command responses (^CC,EE) — fixed 6-byte format,
+                        #     extracted proactively even without a trailing '$'.
+                        #     The EVL firmware sometimes omits the '$' terminator
+                        #     on command acks, causing them to sit in the buffer
+                        #     until the next '$'-terminated message arrives — by
+                        #     which time the 5 s command timeout has already
+                        #     fired (Bug 18).  Extracting them immediately by
+                        #     pattern avoids this.
+                        #  2. '$'-terminated TPI messages (Honeywell/Uno events,
+                        #     command responses WITH '$').  Processed immediately
+                        #     without waiting for a trailing '\r\n' (Bug 13).
+                        #  3. '\n'-terminated messages (login prompts, DSC panel).
+                        #
+                        # After extraction, fused multi-message packets are split
+                        # into independent messages before dispatch (Bugs 14/17).
                         while self._recv_buffer:
+                            # Priority 1: proactive command response extraction.
+                            # Command acks are always ^CC,EE (6 ASCII bytes).
+                            # Extract them even without a trailing '$' so the
+                            # command queue is unblocked immediately (Bug 18).
+                            cmd_resp = re.match(
+                                rb'\^[0-9A-Fa-f]{2},[0-9A-Fa-f]{2}',
+                                self._recv_buffer,
+                            )
+                            if cmd_resp:
+                                end = cmd_resp.end()
+                                raw = self._recv_buffer[:end]
+                                self._recv_buffer = self._recv_buffer[end:]
+                                # Consume the optional trailing '$' that IS
+                                # present on well-formed responses.
+                                if self._recv_buffer.startswith(b'$'):
+                                    self._recv_buffer = self._recv_buffer[1:]
+                                msg = raw.decode("ascii") + "$"
+                                _LOGGER.debug("{---------------------------------------")
+                                _LOGGER.debug("RX < %s", msg)
+                                self.process_data(msg)
+                                _LOGGER.debug("}---------------------------------------")
+                                continue
+
+                            # Priority 2 & 3: '$' and '\n' delimited messages.
                             dollar_pos = self._recv_buffer.find(b'$')
                             newline_pos = self._recv_buffer.find(b'\n')
 
@@ -177,23 +227,21 @@ class EnvisalinkClient:
                             try:
                                 msg = raw.decode("ascii").strip()
                             except UnicodeDecodeError:
-                                _LOGGER.warning("Received non-ASCII data from EVL, replacing invalid bytes: %r", raw)
-                                msg = raw.decode("ascii", errors="replace").strip()
+                                # Non-ASCII bytes in a TPI message mean the data is corrupted
+                                # (e.g. buffer bleed from a previous connection, or hardware
+                                # noise).  Discard the entire frame rather than forwarding
+                                # garbled content to the protocol handlers, which would
+                                # corrupt alarm state and generate spurious errors.
+                                _LOGGER.warning(
+                                    "Received non-ASCII data from EVL; discarding corrupted frame: %r",
+                                    raw,
+                                )
+                                continue
 
                             if not msg:
                                 continue
 
-                            # Split fused packets where a bare %XX notification code (no
-                            # data, no $ terminator) is directly concatenated with a ^YY
-                            # command response, e.g. "%02^00,00$" → "%02$" + "^00,00$".
-                            # Detected when ^ appears before the first comma — i.e. in
-                            # the code position, not a data field.
-                            first_comma = msg.find(',')
-                            caret = msg.find('^')
-                            if msg.startswith('%') and caret != -1 and (first_comma == -1 or caret < first_comma):
-                                to_process = [msg[:caret] + '$', msg[caret:]]
-                            else:
-                                to_process = [msg]
+                            to_process = self._split_fused_messages(msg)
 
                             for m in to_process:
                                 _LOGGER.debug("{---------------------------------------")
@@ -221,10 +269,51 @@ class EnvisalinkClient:
             next_send = time.time() + interval
 
             if self._loggedin:
-                await action()
+                # Skip keepalives when the command queue already has in-flight
+                # or pending commands.  The queued commands prove the connection
+                # is alive; adding a keepalive just competes for the single-
+                # command pipeline and can time out under heavy traffic (e.g.
+                # rapid addon keypresses during panel scanning).  Zone timer
+                # dumps (the other periodic action) are also skipped to avoid
+                # stacking on a busy queue — they will run on the next cycle.
+                #
+                # Also skip if we recently received data from the EVL —
+                # receiving ANY data (keypad updates, etc.) confirms the TCP
+                # session is alive, making a keepalive probe redundant.
+                since_last_rx = time.time() - self._lastReceivedTime
+                if self._commandQueue:
+                    _LOGGER.debug(
+                        "Skipping periodic %s — command queue has %d pending command(s)",
+                        action.__name__,
+                        len(self._commandQueue),
+                    )
+                elif since_last_rx < interval:
+                    _LOGGER.debug(
+                        "Skipping periodic %s — data received %.1fs ago "
+                        "(within %ds interval)",
+                        action.__name__,
+                        since_last_rx,
+                        interval,
+                    )
+                else:
+                    await action()
 
-            now = time.time()
-            await asyncio.sleep(max(0, next_send - now))
+            # If there are outstanding command timeouts, the connection may
+            # be dead.  Shorten the sleep to retry quickly (10s) instead of
+            # waiting the full interval (60s).  This brings dead-connection
+            # detection from ~4 min (3 × 60s cycles) down to ~30s.
+            if self._consecutive_timeouts > 0:
+                retry_delay = 10.0
+                _LOGGER.debug(
+                    "Shortening %s interval to %.0fs due to %d consecutive timeout(s)",
+                    action.__name__,
+                    retry_delay,
+                    self._consecutive_timeouts,
+                )
+                await asyncio.sleep(retry_delay)
+            else:
+                now = time.time()
+                await asyncio.sleep(max(0, next_send - now))
 
     async def connect(self):
         _LOGGER.info(
@@ -337,7 +426,7 @@ class EnvisalinkClient:
 
     async def keypresses_to_default_partition(self, keypresses):
         """Public method for sending a key to a particular partition."""
-        self.send_data(keypresses)
+        await self.send_data(keypresses)
 
     async def keypresses_to_partition(self, partitionNumber, keypresses):
         """Public method to send a key to the default partition."""
@@ -386,7 +475,16 @@ class EnvisalinkClient:
     def process_data(self, data) -> str:
         cmd = self.parseHandler(data)
 
+        if cmd is None:
+            return
+
         result = None
+        try:
+            handlerFunc = getattr(self, cmd["handler"])
+        except (AttributeError, KeyError) as err:
+            _LOGGER.debug("No handler configured for evl command: %s", cmd.get("code", "?"))
+            return
+
         try:
             _LOGGER.debug(
                 str.format(
@@ -396,25 +494,73 @@ class EnvisalinkClient:
                     cmd["data"],
                 )
             )
-            handlerFunc = getattr(self, cmd["handler"])
             result = handlerFunc(cmd["code"], cmd["data"])
 
-        except (AttributeError, TypeError, KeyError) as err:
-            _LOGGER.debug("No handler configured for evl command.")
         except Exception as err:
+            # Bug 23b: Previously, KeyError from inside handlers (e.g.
+            # alarm_state["zone"][invalid_key]) was caught by the same
+            # clause that handled "no handler found", silently swallowing
+            # the error and suppressing callbacks.  Now all handler
+            # exceptions are logged with full context.
             _LOGGER.warning(
-                "Error processing EVL data (code=%s): %s",
-                cmd.get("code", "?") if isinstance(cmd, dict) else "?",
+                "Error in handler %s for code %s: %s: %s",
+                cmd["handler"],
+                cmd.get("code", "?"),
+                type(err).__name__,
                 err,
             )
 
         try:
             _LOGGER.debug("Invoking state change callbacks")
-            if result and cmd["state_change"]:
+            if result and cmd.get("state_change"):
                 self.handle_state_change_callbacks(result)
 
         except (AttributeError, TypeError, KeyError) as ex:
             _LOGGER.debug("No callback configured for evl command. %r", ex)
+
+    # Compiled once at class level — matches a TPI message sentinel (%XX or ^XX)
+    # where XX = two hex digits.
+    _SENTINEL_RE = re.compile(r'[%\^][0-9A-Fa-f]{2}')
+
+    def _split_fused_messages(self, msg):
+        """Split a TPI message that may contain multiple fused messages.
+
+        The EVL firmware sometimes sends two messages concatenated without
+        a '$' delimiter between the first and second.  Known patterns:
+
+            %XX^YY  (Bug 14) — bare notification + command response
+            %XX%YY  (Bug 17) — two notifications fused
+            ^XX%YY  — command response + notification
+            ^XX^YY  — two command responses fused
+
+        The method scans for a second sentinel (%XX or ^XX, two hex digits)
+        after the initial 3-character code.  If found it splits the message
+        at that point.  Compound response codes like %00%00 are recognised
+        via ``_evl_ResponseTypes`` and are NOT split.
+
+        Returns a list of individual message strings to dispatch.
+        """
+        for m in self._SENTINEL_RE.finditer(msg, pos=3):
+            split_pos = m.start()
+
+            # A sentinel immediately after the leading code (position 3)
+            # might be part of a compound code like %00%00.  Check if the
+            # 6-char prefix is a known response type before splitting.
+            if split_pos == 3:
+                compound = msg[:m.end()]                     # e.g. "%00%00"
+                if getattr(self, '_evl_ResponseTypes', None) and compound in self._evl_ResponseTypes:
+                    continue                                  # known compound — don't split
+
+            # Found a fused message boundary — split here.
+            first = msg[:split_pos]
+            if not first.endswith('$'):
+                first += '$'
+            rest = msg[split_pos:]
+            _LOGGER.debug("Split fused message: %r → %r + %r", msg, first, rest)
+            return [first] + self._split_fused_messages(rest)
+
+        # No fused boundary detected.
+        return [msg]
 
     def handle_state_change_callbacks(self, updates):
         for change_type, values in updates.items():
@@ -682,11 +828,15 @@ class EnvisalinkClient:
         if self._commandQueue:
             op = self._commandQueue[0]
             if cmd and op.cmd != cmd:
-                _LOGGER.error(
-                    (
-                        "Command acknowledgement received is different for a different command "
-                        "(%s) than was issued (%s)"
-                    ),
+                # A late ack for a previously timed-out command has arrived while a
+                # different command is now in-flight.  The in-flight command will get
+                # its own ack; do NOT mark it succeeded here.  This is a benign race
+                # that can occur when keepalives and keypresses overlap in the queue,
+                # or when an ack is delayed enough to arrive after the command clock
+                # advanced.  Not actionable — log at WARNING, not ERROR.
+                _LOGGER.warning(
+                    "Received ack for command '%s' but command '%s' is currently in-flight; "
+                    "treating as a late ack (expected during normal keepalive/keypress overlap)",
                     cmd,
                     op.cmd,
                 )

--- a/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
@@ -13,8 +13,10 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-_RECONNECT_MIN_TIME = 2
+_RECONNECT_MIN_TIME = 10
 _RECONNECT_MAX_TIME = 128
+_MAX_CONSECUTIVE_TIMEOUTS = 3
+_MAX_RETRY_DELAY = 10
 
 class EnvisalinkClient:
     """Abstract base class for the envisalink TPI client."""
@@ -54,6 +56,7 @@ class EnvisalinkClient:
         self._activeTasks = set()
         self._reconnect_time = _RECONNECT_MIN_TIME
         self._connect_time = 0
+        self._consecutive_timeouts = 0
 
     def create_internal_task(self, coro, name=None):
         task = self._eventLoop.create_task(coro, name=name)
@@ -127,6 +130,13 @@ class EnvisalinkClient:
                             continue
                         except asyncio.IncompleteReadError:
                             data = None
+                        except (ConnectionResetError, OSError, BrokenPipeError) as ex:
+                            _LOGGER.warning("Connection error while reading data: %s", ex)
+                            await self.disconnect()
+                            # Increase backoff so we don't hammer the EVL with
+                            # rapid reconnect attempts when it keeps resetting.
+                            self._reconnect_time = min(self._reconnect_time * 2, _RECONNECT_MAX_TIME)
+                            break
 
                         if not data:
                             if self._writer:
@@ -134,16 +144,35 @@ class EnvisalinkClient:
                                 await self.disconnect()
                             break
 
-                        data = data.decode("ascii")
-                        _LOGGER.debug("{---------------------------------------")
-                        _LOGGER.debug(str.format("RX < {0}", data))
+                        try:
+                            data = data.decode("ascii")
+                        except UnicodeDecodeError:
+                            _LOGGER.warning("Received non-ASCII data from EVL, replacing invalid bytes: %r", data)
+                            data = data.decode("ascii", errors="replace")
 
-                        self.process_data(data.strip())
-                        _LOGGER.debug("}---------------------------------------")
+                        # Handle EVL firmware quirk: multiple $-terminated TPI
+                        # messages sometimes arrive on a single line without
+                        # \r\n separators between them.  Split on '$' so each
+                        # message is processed individually; otherwise command
+                        # responses fused with keypad updates are silently lost,
+                        # causing keepalive timeouts.
+                        stripped = data.strip()
+                        if '$' in stripped:
+                            messages = [s.strip() + '$' for s in stripped.split('$') if s.strip()]
+                        else:
+                            messages = [stripped]
+
+                        for msg in messages:
+                            _LOGGER.debug("{---------------------------------------")
+                            _LOGGER.debug("RX < %s", msg)
+                            self.process_data(msg)
+                            _LOGGER.debug("}---------------------------------------")
 
             except Exception as ex:
                 _LOGGER.error("Caught unexpected exception: %r", ex)
                 await self.disconnect()
+                # Increase backoff for immediate post-connect failures
+                self._reconnect_time = min(self._reconnect_time * 2, _RECONNECT_MAX_TIME)
 
             # Lost connection so reattempt connection in a bit
             if not self._shutdown:
@@ -162,7 +191,7 @@ class EnvisalinkClient:
                 await action()
 
             now = time.time()
-            await asyncio.sleep(next_send - now)
+            await asyncio.sleep(max(0, next_send - now))
 
     async def connect(self):
         _LOGGER.info(
@@ -181,13 +210,12 @@ class EnvisalinkClient:
             _LOGGER.info("Connection Successful!")
 
             self._alarmPanel.handle_connection_status(True)
-            self._reconnect_time = _RECONNECT_MIN_TIME
             self._connect_time = time.time()
             return
         except asyncio.exceptions.TimeoutError:
             _LOGGER.error("Timed out connecting to the envisalink at %s", self._alarmPanel.host)
             if not self._shutdown:
-                self._alarmPanel._loginTimeoutCallback(False)
+                self._alarmPanel._loginTimeoutCallback()
             await self.disconnect()
         except ConnectionResetError:
             _LOGGER.error(
@@ -200,9 +228,7 @@ class EnvisalinkClient:
             await self.disconnect()
 
         # Increase time before reconnect attempt
-        self._reconnect_time *= 2
-        if self._reconnect_time > _RECONNECT_MAX_TIME:
-            self._reconnect_time = _RECONNECT_MIN_TIME
+        self._reconnect_time = min(self._reconnect_time * 2, _RECONNECT_MAX_TIME)
 
     async def disconnect(self):
         """Internal method for forcing connection closure if hung."""
@@ -225,7 +251,9 @@ class EnvisalinkClient:
         # Tear down the connection
         try:
             writer.close()
-            await writer.wait_closed()
+            await asyncio.wait_for(writer.wait_closed(), timeout=5)
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Timed out waiting for connection to close.")
         except Exception as ex:
             if not self._shutdown:
                 _LOGGER.error("Exception while closing connection: %s", ex)
@@ -335,6 +363,12 @@ class EnvisalinkClient:
 
         except (AttributeError, TypeError, KeyError) as err:
             _LOGGER.debug("No handler configured for evl command.")
+        except Exception as err:
+            _LOGGER.warning(
+                "Error processing EVL data (code=%s): %s",
+                cmd.get("code", "?") if isinstance(cmd, dict) else "?",
+                err,
+            )
 
         try:
             _LOGGER.debug("Invoking state change callbacks")
@@ -397,6 +431,8 @@ class EnvisalinkClient:
     def handle_login_success(self, code, data):
         """Handler for when the envisalink accepts our credentials."""
         self._loggedin = True
+        self._reconnect_time = _RECONNECT_MIN_TIME
+        self._consecutive_timeouts = 0
         _LOGGER.debug("Password accepted, session created")
         self._alarmPanel.handle_login_success()
 
@@ -518,9 +554,7 @@ class EnvisalinkClient:
                         # Still waiting on a response from the EVL so break out of loop and wait
                         # for the response
                         if now >= op.expiryTime:
-                            # Timeout waiting for response from the EVL so fail the command,
-                            # This is likely due to the EVL becoming unresponsive so tear down the
-                            # connection to start a recovery.
+                            # Timeout waiting for response from the EVL so fail the command.
                             _LOGGER.error(
                                 (
                                     "Command '%s' failed due to timeout waiting for response "
@@ -529,7 +563,13 @@ class EnvisalinkClient:
                                 op.cmd,
                             )
                             op.state = self.Operation.State.FAILED
-                            await self.disconnect()
+                            self._consecutive_timeouts += 1
+                            if self._consecutive_timeouts >= _MAX_CONSECUTIVE_TIMEOUTS:
+                                _LOGGER.error(
+                                    "%d consecutive command timeouts; disconnecting to recover.",
+                                    self._consecutive_timeouts,
+                                )
+                                await self.disconnect()
                         break
                     elif op.state == self.Operation.State.QUEUED:
                         # Send command to the EVL
@@ -575,6 +615,7 @@ class EnvisalinkClient:
 
     def command_succeeded(self, cmd):
         """Indicate that a command has been successfully processed by the EVL."""
+        self._consecutive_timeouts = 0
 
         if self._commandQueue:
             op = self._commandQueue[0]
@@ -590,8 +631,9 @@ class EnvisalinkClient:
             else:
                 op.state = self.Operation.State.SUCCEEDED
         else:
-            _LOGGER.error(
-                f"Command acknowledgement received for '{cmd}' when no command was issued."
+            _LOGGER.warning(
+                "Late command acknowledgement received for '%s' (no pending command).",
+                cmd,
             )
 
         # Wake up the command processing task to process this result
@@ -611,8 +653,7 @@ class EnvisalinkClient:
                 # Update the retry delay based on an exponential backoff
                 op.retryDelay *= 2
 
-                if op.retryDelay >= self._alarmPanel.command_timeout:
-                    # Don't extend the retry delay beyond the overall command timeout
+                if op.retryDelay >= _MAX_RETRY_DELAY:
                     _LOGGER.error("Maximum command retries attempted; aborting command.")
                     op.state = self.Operation.State.FAILED
                 else:

--- a/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
@@ -58,6 +58,7 @@ class EnvisalinkClient:
         self._connect_time = 0
         self._consecutive_timeouts = 0
         self._lastReceivedTime = 0
+        self._recv_buffer = b""
 
     def create_internal_task(self, coro, name=None):
         task = self._eventLoop.create_task(coro, name=name)
@@ -121,16 +122,14 @@ class EnvisalinkClient:
                     while not self._shutdown and self._reader:
                         _LOGGER.debug("Waiting for data from EVL")
                         try:
-                            data = await asyncio.wait_for(
-                                self._reader.readuntil(separator=b"\n"), 5
+                            chunk = await asyncio.wait_for(
+                                self._reader.read(4096), 5
                             )
                         except asyncio.exceptions.TimeoutError:
                             if not self._loggedin and ((time.time() - self._connect_time) > self._alarmPanel.connection_timeout):
                                 _LOGGER.error("Timed out waiting to complete login handshake; disconnecting.")
                                 await self.disconnect()
                             continue
-                        except asyncio.IncompleteReadError:
-                            data = None
                         except (ConnectionResetError, OSError, BrokenPipeError) as ex:
                             _LOGGER.warning("Connection error while reading data: %s", ex)
                             await self.disconnect()
@@ -139,37 +138,68 @@ class EnvisalinkClient:
                             self._reconnect_time = min(self._reconnect_time * 2, _RECONNECT_MAX_TIME)
                             break
 
-                        if not data:
+                        if not chunk:
                             if self._writer:
                                 _LOGGER.error("The server closed the connection.")
                                 await self.disconnect()
                             break
 
-                        try:
-                            data = data.decode("ascii")
-                        except UnicodeDecodeError:
-                            _LOGGER.warning("Received non-ASCII data from EVL, replacing invalid bytes: %r", data)
-                            data = data.decode("ascii", errors="replace")
-
+                        self._recv_buffer += chunk
                         self._lastReceivedTime = time.time()
+                        _LOGGER.debug("RAW << %r", chunk)
 
-                        # Handle EVL firmware quirk: multiple $-terminated TPI
-                        # messages sometimes arrive on a single line without
-                        # \r\n separators between them.  Split on '$' so each
-                        # message is processed individually; otherwise command
-                        # responses fused with keypad updates are silently lost,
-                        # causing keepalive timeouts.
-                        stripped = data.strip()
-                        if '$' in stripped:
-                            messages = [s.strip() + '$' for s in stripped.split('$') if s.strip()]
-                        else:
-                            messages = [stripped]
+                        # Extract and process all complete messages from the buffer.
+                        # TPI messages (Honeywell/Uno) are '$'-terminated and may arrive
+                        # without a trailing \r\n, so we process on '$' immediately rather
+                        # than waiting for a newline.  Login and DSC messages are always
+                        # '\n'-terminated without '$'.  Processing on '$' eliminates the
+                        # readuntil(\n) blocking delay that was the root cause of keepalive
+                        # timeouts (see Bug 14).
+                        while self._recv_buffer:
+                            dollar_pos = self._recv_buffer.find(b'$')
+                            newline_pos = self._recv_buffer.find(b'\n')
 
-                        for msg in messages:
-                            _LOGGER.debug("{---------------------------------------")
-                            _LOGGER.debug("RX < %s", msg)
-                            self.process_data(msg)
-                            _LOGGER.debug("}---------------------------------------")
+                            if dollar_pos == -1 and newline_pos == -1:
+                                # No complete message yet; wait for more data
+                                break
+
+                            if dollar_pos != -1 and (newline_pos == -1 or dollar_pos < newline_pos):
+                                # '$' arrives before '\n': extract TPI message up to and
+                                # including '$', without waiting for a trailing newline.
+                                raw = self._recv_buffer[:dollar_pos + 1]
+                                self._recv_buffer = self._recv_buffer[dollar_pos + 1:]
+                            else:
+                                # '\n' arrives first (or no '$'): newline-terminated message
+                                # (Honeywell login challenge, DSC panel messages).
+                                raw = self._recv_buffer[:newline_pos + 1]
+                                self._recv_buffer = self._recv_buffer[newline_pos + 1:]
+
+                            try:
+                                msg = raw.decode("ascii").strip()
+                            except UnicodeDecodeError:
+                                _LOGGER.warning("Received non-ASCII data from EVL, replacing invalid bytes: %r", raw)
+                                msg = raw.decode("ascii", errors="replace").strip()
+
+                            if not msg:
+                                continue
+
+                            # Split fused packets where a bare %XX notification code (no
+                            # data, no $ terminator) is directly concatenated with a ^YY
+                            # command response, e.g. "%02^00,00$" → "%02$" + "^00,00$".
+                            # Detected when ^ appears before the first comma — i.e. in
+                            # the code position, not a data field.
+                            first_comma = msg.find(',')
+                            caret = msg.find('^')
+                            if msg.startswith('%') and caret != -1 and (first_comma == -1 or caret < first_comma):
+                                to_process = [msg[:caret] + '$', msg[caret:]]
+                            else:
+                                to_process = [msg]
+
+                            for m in to_process:
+                                _LOGGER.debug("{---------------------------------------")
+                                _LOGGER.debug("RX < %s", m)
+                                self.process_data(m)
+                                _LOGGER.debug("}---------------------------------------")
 
             except Exception as ex:
                 _LOGGER.error("Caught unexpected exception: %r", ex)
@@ -179,7 +209,7 @@ class EnvisalinkClient:
 
             # Lost connection so reattempt connection in a bit
             if not self._shutdown:
-                _LOGGER.error("Reconnection attempt in %ds", self._reconnect_time)
+                _LOGGER.warning("Reconnection attempt in %ds", self._reconnect_time)
                 await asyncio.sleep(self._reconnect_time)
 
         await self.disconnect()
@@ -246,6 +276,7 @@ class EnvisalinkClient:
         self._reader = None
 
         self._loggedin = False
+        self._recv_buffer = b""
 
         # Fail all outstanding commands
         for op in self._commandQueue:
@@ -257,9 +288,13 @@ class EnvisalinkClient:
             await asyncio.wait_for(writer.wait_closed(), timeout=5)
         except asyncio.TimeoutError:
             _LOGGER.warning("Timed out waiting for connection to close.")
+        except (ConnectionResetError, BrokenPipeError, OSError) as ex:
+            # Socket was already closed by the remote end; not an error.
+            if not self._shutdown:
+                _LOGGER.debug("Connection already closed by remote end: %s", ex)
         except Exception as ex:
             if not self._shutdown:
-                _LOGGER.error("Exception while closing connection: %s", ex)
+                _LOGGER.warning("Exception while closing connection: %s", ex)
 
         # Clean out all the failed commands from the queue
         self._commandEvent.set()
@@ -558,15 +593,22 @@ class EnvisalinkClient:
                         # for the response
                         if now >= op.expiryTime:
                             # Timeout waiting for response from the EVL so fail the command.
-                            _LOGGER.error(
-                                (
-                                    "Command '%s' failed due to timeout waiting for response "
-                                    "from EVL"
-                                ),
-                                op.cmd,
-                            )
-                            op.state = self.Operation.State.FAILED
                             self._consecutive_timeouts += 1
+                            if self._consecutive_timeouts >= _MAX_CONSECUTIVE_TIMEOUTS:
+                                _LOGGER.error(
+                                    "Command '%s' failed due to timeout (%d/%d consecutive)",
+                                    op.cmd,
+                                    self._consecutive_timeouts,
+                                    _MAX_CONSECUTIVE_TIMEOUTS,
+                                )
+                            else:
+                                _LOGGER.warning(
+                                    "Command '%s' timed out (%d/%d); will disconnect if this continues",
+                                    op.cmd,
+                                    self._consecutive_timeouts,
+                                    _MAX_CONSECUTIVE_TIMEOUTS,
+                                )
+                            op.state = self.Operation.State.FAILED
                             if self._consecutive_timeouts >= _MAX_CONSECUTIVE_TIMEOUTS:
                                 # Only force a reconnect if the EVL has been completely silent.
                                 # If the EVL is still sending unsolicited updates (e.g. keypad
@@ -651,8 +693,12 @@ class EnvisalinkClient:
             else:
                 op.state = self.Operation.State.SUCCEEDED
         else:
-            _LOGGER.warning(
-                "Late command acknowledgement received for '%s' (no pending command).",
+            # The EVL responded after the command timed out and was removed from
+            # the queue. The connection is alive — _consecutive_timeouts was
+            # already reset above. Log at debug; it is not actionable.
+            _LOGGER.debug(
+                "Late command acknowledgement received for '%s' (no pending command); "
+                "EVL is alive but responded after timeout.",
                 cmd,
             )
 

--- a/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py
@@ -57,6 +57,7 @@ class EnvisalinkClient:
         self._reconnect_time = _RECONNECT_MIN_TIME
         self._connect_time = 0
         self._consecutive_timeouts = 0
+        self._lastReceivedTime = 0
 
     def create_internal_task(self, coro, name=None):
         task = self._eventLoop.create_task(coro, name=name)
@@ -149,6 +150,8 @@ class EnvisalinkClient:
                         except UnicodeDecodeError:
                             _LOGGER.warning("Received non-ASCII data from EVL, replacing invalid bytes: %r", data)
                             data = data.decode("ascii", errors="replace")
+
+                        self._lastReceivedTime = time.time()
 
                         # Handle EVL firmware quirk: multiple $-terminated TPI
                         # messages sometimes arrive on a single line without
@@ -565,11 +568,28 @@ class EnvisalinkClient:
                             op.state = self.Operation.State.FAILED
                             self._consecutive_timeouts += 1
                             if self._consecutive_timeouts >= _MAX_CONSECUTIVE_TIMEOUTS:
-                                _LOGGER.error(
-                                    "%d consecutive command timeouts; disconnecting to recover.",
-                                    self._consecutive_timeouts,
-                                )
-                                await self.disconnect()
+                                # Only force a reconnect if the EVL has been completely silent.
+                                # If the EVL is still sending unsolicited updates (e.g. keypad
+                                # updates during zone trips with newer firmware), it is alive and
+                                # connected — it is just slow to acknowledge our command.
+                                # Disconnecting in that case makes things worse, not better.
+                                silent_duration = now - self._lastReceivedTime
+                                if silent_duration > self._alarmPanel.command_timeout:
+                                    _LOGGER.error(
+                                        "%d consecutive command timeouts and EVL has been silent "
+                                        "for %.1fs; disconnecting to recover.",
+                                        self._consecutive_timeouts,
+                                        silent_duration,
+                                    )
+                                    await self.disconnect()
+                                else:
+                                    _LOGGER.warning(
+                                        "%d consecutive command timeouts but EVL is still "
+                                        "sending data (last received %.1fs ago); not "
+                                        "disconnecting.",
+                                        self._consecutive_timeouts,
+                                        silent_duration,
+                                    )
                         break
                     elif op.state == self.Operation.State.QUEUED:
                         # Send command to the EVL

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -189,9 +189,16 @@ class HoneywellClient(EnvisalinkClient):
             dataList[4] = ",".join(dataList[4:])
             del dataList[5:]
 
-        if len(dataList) < 5:
+        if len(dataList) < 4:
             _LOGGER.warning("Keypad data from Envisalink has too few fields (%d), ignoring: %s", len(dataList), data)
             return
+
+        if len(dataList) == 4:
+            # Newer EVL-4 firmware omits the alpha display text field during zone trips.
+            # Treat it as an empty string and continue processing so zone/partition state
+            # updates are not silently dropped.
+            _LOGGER.debug("Keypad data from Envisalink has 4 fields (no alpha); treating alpha as empty: %s", data)
+            dataList.append("")
 
         partitionNumber = int(dataList[0])
         if not (partitionNumber in self._zoneTimers.keys()):
@@ -204,7 +211,12 @@ class HoneywellClient(EnvisalinkClient):
         except ValueError:
             user_zone_field = None
         beep_field = Beep_Flags()
-        beep_field.asByte = int(dataList[3], 16)
+        try:
+            # Mask to 8 bits — newer firmware may send a longer hex string in this field
+            beep_field.asByte = int(dataList[3], 16) & 0xFF
+        except (ValueError, OverflowError):
+            _LOGGER.debug("Unable to parse beep field '%s' for partition %s; defaulting to 0", dataList[3], dataList[0])
+            beep_field.asByte = 0
         beep = evl_Virtual_Keypad_How_To_Beep.get(beep_field.beeps, "unknown")
         armed_night = bool(beep_field.armed_night)
         alpha = dataList[4]

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -188,10 +188,9 @@ class HoneywellClient(EnvisalinkClient):
         if len(dataList) > 5:
             dataList[4] = ",".join(dataList[4:])
             del dataList[5:]
-        # make sure data is in format we expect, current TPI seems to send bad data every so often
-        # TODO: Make this a regex...
-        if "%" in data:
-            _LOGGER.error("Data format invalid from Envisalink, ignoring...")
+
+        if len(dataList) < 5:
+            _LOGGER.warning("Keypad data from Envisalink has too few fields (%d), ignoring: %s", len(dataList), data)
             return
 
         partitionNumber = int(dataList[0])

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -220,6 +220,17 @@ class HoneywellClient(EnvisalinkClient):
         beep = evl_Virtual_Keypad_How_To_Beep.get(beep_field.beeps, "unknown")
         armed_night = bool(beep_field.armed_night)
         alpha = dataList[4]
+
+        # Safety net: Vista panels have a 32-char keypad display (16×2).
+        # Alpha text exceeding this length indicates fused TPI messages
+        # that were not caught by the buffer parser (Bug 15).
+        if len(alpha) > 32:
+            _LOGGER.debug(
+                "Keypad alpha text is %d chars (expected ≤32), truncating: %r",
+                len(alpha), alpha,
+            )
+            alpha = alpha[:32]
+
         partition_status = HoneywellClient.get_partition_state(flags, alpha)
         zone_code = HoneywellClient.get_zone_report_type(flags, alpha)
         prior_ready = self._alarmPanel.alarm_state["partition"][partitionNumber]["status"]["ready"]
@@ -255,9 +266,10 @@ class HoneywellClient(EnvisalinkClient):
             for z in list(self._zoneTimers[partitionNumber]):
                 _LOGGER.debug(f"Timer {z} :: {self._zoneTimers[partitionNumber][z]} Closing")
                 timer = str.split(z, "|")
-                zone_updates.append(int(timer[0]))
-                if timer[1] == "state":
-                    self._alarmPanel.alarm_state["zone"][int(timer[0])]["status"].update(
+                zone_num = int(timer[0])
+                zone_updates.append(zone_num)
+                if zone_num in self._alarmPanel.alarm_state["zone"] and timer[1] == "state":
+                    self._alarmPanel.alarm_state["zone"][zone_num]["status"].update(
                         {"open": False, "fault": False}
                     )
                 self._zoneTimers[partitionNumber].pop(z)
@@ -291,8 +303,22 @@ class HoneywellClient(EnvisalinkClient):
             for z in self._zoneTimers[partitionNumber]:
                 self._zoneTimers[partitionNumber][z] += 1
 
+            # Validate zone number before accessing zone state (Bug 23).
+            # During programming mode the user/zone field may contain
+            # values (e.g. 0 or >max_zones) that are not real zone
+            # numbers.  Accessing alarm_state["zone"] with such a value
+            # raises a KeyError that is silently caught by process_data(),
+            # suppressing the callback and preventing HA sensor updates.
+            valid_zone = user_zone_field in self._alarmPanel.alarm_state["zone"]
+
             # Add a zone timer (if needed) of the appropriate type and update zone status
-            if zone_code in ["battery", "tamper"]:
+            if not valid_zone:
+                _LOGGER.debug(
+                    "user_zone_field %d is not a valid zone number; "
+                    "skipping zone state update (programming mode?)",
+                    user_zone_field,
+                )
+            elif zone_code in ["battery", "tamper"]:
                 # Battery or tamper report for a wireless zone. These are added to the keypad
                 # update queue separate from state changes, so need their own zone timers.
                 self._zoneTimers[partitionNumber][f"{user_zone_field}|{zone_code}"] = 1
@@ -324,9 +350,13 @@ class HoneywellClient(EnvisalinkClient):
                 if self._zoneTimers[partitionNumber][z] > max_timer:
                     _LOGGER.debug(f"Timer {z} :: {self._zoneTimers[partitionNumber][z]} Closing")
                     timer = str.split(z, "|")
-                    zone_updates.append(int(timer[0]))
+                    zone_num = int(timer[0])
+                    if zone_num not in self._alarmPanel.alarm_state["zone"]:
+                        self._zoneTimers[partitionNumber].pop(z)
+                        continue
+                    zone_updates.append(zone_num)
                     if timer[1] == "state":
-                        self._alarmPanel.alarm_state["zone"][int(timer[0])]["status"].update(
+                        self._alarmPanel.alarm_state["zone"][zone_num]["status"].update(
                             {"open": False, "fault": False}
                         )
                     # else:

--- a/custom_components/envisalink_new/pyenvisalink/honeywell_envisalinkdefs.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_envisalinkdefs.py
@@ -89,6 +89,12 @@ evl_ResponseTypes = {
         "handler": "keypad_update",
         "state_change": True,
     },
+    "%00%00": {
+        "name": "Virtual Keypad Zone-Trip Update",
+        "description": "Zone-trip keypad update sent by newer EVL-4 firmware; treated identically to %00.",
+        "handler": "keypad_update",
+        "state_change": True,
+    },
     "%01": {
         "type": "zone",
         "name": "Zone State Change",

--- a/custom_components/envisalink_new/sensor.py
+++ b/custom_components/envisalink_new/sensor.py
@@ -57,6 +57,7 @@ class EnvisalinkKeypadSensor(EnvisalinkDevice, SensorEntity):
         """Initialize the sensor."""
         self._icon = "mdi:alarm-panel"
         self._partition_number = partition_number
+        self._attr_force_update = True
         name = f"Partition {partition_number} Keypad"
         self._attr_unique_id = f"{controller.unique_id}_{name}"
 


### PR DESCRIPTION
# Bug Fixes: Connection Stability

## PR Description (copy/paste for GitHub)

**Status: Testing needed**

This PR fixes 23 connection stability and reliability bugs affecting EVL-3/EVL-4 with Honeywell panels. The main issues addressed:

- Root-cause fix for keepalive timeouts: replaced `readuntil` with a streaming buffer so `$`-terminated responses are processed immediately without waiting for a newline
- Proactive command ACK extraction for bare responses without `$` terminators
- Unified fused multi-message splitter with compound code awareness (`%00%00`)
- Fused multi-message and bare-notification+response packet handling
- Reconnect backoff getting stuck, causing rapid reconnect hammering
- Various exception handling gaps that crash the connection on corrupted data
- Non-ASCII garbage frames now discarded at decode time instead of forwarded to handlers (was corrupting alarm state and keypad sensors under heavy load)
- Adaptive read timeout (5s login / 30s normal) to reduce read-cancellation churn
- Keepalive skip during heavy command traffic (addon scanning) to prevent disconnect storms
- Programming mode keypad updates crashing the handler and suppressing HA sensor updates
- Log level noise (spurious ERROR/WARNING for normal recoverable events)

**Looking for testers** — especially anyone experiencing frequent disconnects, "Data format invalid" errors, or keepalive timeout storms. To test, install from my fork's `bugfix` branch:

1. In HACS: go to the integration → three dots → Redownload → enable "Show beta versions" and point to `MichaelB2018/envisalink_new` branch `bugfix`
2. Or manually copy the 4 changed files from this PR into your `custom_components/envisalink_new/pyenvisalink/` folder
3. Restart Home Assistant

Please report back with your logs after running for 24+ hours.

---

## Summary

This branch fixes multiple interconnected bugs in the connection management layer
that cause a cascading disconnect/reconnect storm — hundreds of error cycles per day,
plus reliability issues during programming mode that suppress HA sensor updates.
These issues affect EVL-3 and EVL-4 devices with both Honeywell and DSC panels.

Related issues: #234, #237

---

## Bug 1: Keepalive timeout triggers full TCP disconnect

**File:** `envisalink_base_client.py` — `process_command_queue()`

**Problem:** When a single keepalive command (`'00'`) doesn't receive a response
within the 5-second command timeout, `disconnect()` is called, tearing down the
entire TCP connection. This is the primary trigger for the disconnect storm.
The keepalive's only purpose is to reset the EVL's watchdog timer — a missed
response does not mean the connection is dead.

**Fix:** Added a `_consecutive_timeouts` counter. A single command timeout now
fails the command but does NOT disconnect. Only after 3 consecutive command
timeouts is `disconnect()` called, indicating the connection is truly unresponsive.
The counter resets on any successful command acknowledgement and on login success.

---

## Bug 2: Reconnect backoff permanently stuck at 2 seconds

**File:** `envisalink_base_client.py` — `connect()`

**Problem:** After a disconnect, the reconnect backoff is supposed to increase
exponentially (2s → 4s → 8s → ...). However, `connect()` resets
`_reconnect_time` back to the minimum (2s) as soon as the TCP handshake succeeds
— before login completes. The EVL-4 accepts the TCP SYN/ACK (resetting the
backoff to 2s) but then immediately sends a Connection Reset because the old
session hasn't been released yet. The `ConnectionResetError` is caught by the
outer exception handler in `read_loop()`, which does not increase the backoff.

Result: every reconnect attempt resets to 2s → infinite 2-second hammering loop
that prevents the EVL from ever releasing the old session.

**Evidence from logs:**
```
Reconnection attempt in 2s  (repeated 435+ times)
Caught unexpected exception: ConnectionResetError(104, 'Connection reset by peer')
```

**Fix:** Moved the `_reconnect_time` reset from `connect()` (TCP success) to
`handle_login_success()` (full authentication). TCP acceptance without login
no longer resets the backoff. Additionally, the outer exception handler in
`read_loop()` now increases the backoff on immediate post-connect failures.

---

## Bug 3: Backoff cap resets to minimum instead of capping

**File:** `envisalink_base_client.py` — `connect()`

**Problem:** When the exponential backoff exceeds `_RECONNECT_MAX_TIME` (128s),
it resets to `_RECONNECT_MIN_TIME` instead of capping at the maximum.
This creates a sawtooth pattern: 2→4→8→16→32→64→128→2→4→...

**Fix:** Changed to cap at `_RECONNECT_MAX_TIME` using `min()`.

---

## Bug 4: ConnectionResetError not caught in read loop

**File:** `envisalink_base_client.py` — `read_loop()` inner try/except

**Problem:** The inner read loop only catches `TimeoutError` and
`IncompleteReadError`. `ConnectionResetError`, `OSError`, and `BrokenPipeError`
bubble up to the outer catch-all exception handler, which provides no specific
handling and generates alarming error logs.

**Fix:** Added explicit except clauses for `ConnectionResetError`, `OSError`,
and `BrokenPipeError` in the inner read loop. These are logged as warnings and
cleanly break the inner loop to trigger reconnection, rather than crashing to
the outer handler.

---

## Bug 5: TypeError crash permanently breaks reconnect (issue #237)

**File:** `envisalink_base_client.py` — `connect()`

**Problem:** When `connect()` times out, it calls:
```python
self._alarmPanel._loginTimeoutCallback(False)
```
But the callback (`controller.py` `async_login_timeout_callback`) accepts no
arguments (only `self`). This throws:
```
TypeError: async_login_timeout_callback() takes 1 positional argument but 2 were given
```
The `TypeError` is caught by the outer `read_loop()` exception handler, which
reconnects after some delay — but every subsequent reconnect attempt that times
out hits the same `TypeError`. The integration becomes permanently stuck and
cannot recover without restarting Home Assistant.

**Fix:** Removed the `False` argument from the `_loginTimeoutCallback()` call.
The default callback (a `functools.partial`) already has its argument bound, and
the controller callback expects no arguments — so calling with no args is correct
for both cases.

---

## Bug 6: UnicodeDecodeError crash from corrupted EVL data (issue #234)

**File:** `envisalink_base_client.py` — `read_loop()`

**Problem:** Data from the EVL is decoded with `data.decode("ascii")`. If the EVL
sends any non-ASCII bytes (e.g. corrupted data due to hardware issues), this throws
a `UnicodeDecodeError` which crashes the read loop and triggers a full disconnect.

**Example from issue #234 logs:**
```
b'FAULT 20 MASTER BEDR\xba\xbaOM 2 $\r\n'
UnicodeDecodeError: 'ascii' ordinal not in range(128)
```

**Initial fix (superseded by Bug 15):** Wrapped the decode in a try/except that
fell back to `data.decode("ascii", errors="replace")`. This prevented the crash,
but forwarding replacement-character strings (`U+FFFD`) to the protocol handlers
turned out to cause worse secondary damage (see Bug 15).

**Final fix (Bug 15):** On `UnicodeDecodeError`, the corrupt frame is discarded
entirely (`continue`). A WARNING is logged with the raw bytes for hardware diagnosis.
This is correct because the EVL TPI protocol is pure 7-bit ASCII — no valid message
can ever contain non-ASCII bytes, so there is nothing worth salvaging in a frame
that contains them.

---

## Bug 7: Negative sleep in periodic keepalive

**File:** `envisalink_base_client.py` — `periodic_command()`

**Problem:** The keepalive interval calculation `next_send - now` can produce a
negative value when the keepalive action blocks longer than the interval (e.g.
during a disconnect/reconnect cycle). `asyncio.sleep()` with a negative value
sleeps for 0, causing an immediate re-send loop.

**Fix:** Changed to `max(0, next_send - now)`.

---

## Bug 8: Minimum reconnect time too aggressive

**File:** `envisalink_base_client.py`

**Problem:** `_RECONNECT_MIN_TIME` is 2 seconds. The EVL-4 (and EVL-3) needs
time to release a TCP session after disconnect. Reconnecting after just 2 seconds
almost always hits the EVL before it's ready, causing "Connection reset by peer"
or "another client is already connected" errors.

**Fix:** Increased `_RECONNECT_MIN_TIME` from 2s to 10s.

---

## Additional Improvements

- **Better error logging in `disconnect()`:** Added a 5-second timeout on
  `writer.wait_closed()` to prevent `disconnect()` from hanging if the TCP socket
  can't close cleanly.

---

## Bug 9: Fused multi-message lines cause keepalive timeouts

**File:** `envisalink_base_client.py` — `read_loop()`

**Problem:** The EVL firmware sometimes sends multiple `$`-terminated TPI messages
on a single line without `\r\n` separators between them, e.g.:
```
%00,01,1C08,08,00,ARMED STAY$^00,00$\r\n
```
The `readuntil("\n")` call reads this as one line. The greedy regex in
`parseHandler` (`([%\^].+)\$`) matches from the first `%` to the **last** `$`,
treating the entire line as a single message. The command response (`^00,00$`) is
swallowed into the keypad update's data and never processed.

This is the **primary cause** of the persistent keepalive (`'00'`) timeouts
— the EVL IS responding, but the response is embedded in a fused message and
silently lost. It also explains:
- **"Data format invalid from Envisalink"** errors: the second message's `%00`
  code appears in the first message's data, triggering the `"%" in data` check
  in `handle_keypad_update`.
- **Late command acknowledgements** ("when no command was issued"): the EVL
  occasionally re-sends or the response arrives on a separate line after the
  command has already timed out and been removed from the queue.

**Fix:** After decoding each line from the EVL, split on `$` and process each
non-empty segment as an independent TPI message. Login messages (which don't
contain `$`) are unaffected.

---

## Bug 10: No backoff on post-connect ConnectionResetError

**File:** `envisalink_base_client.py` — `read_loop()` inner exception handler

**Problem:** When `connect()` succeeds (TCP handshake completes) but the read loop
immediately gets `ConnectionResetError` (EVL rejects because its old session hasn't
been released), the `_reconnect_time` is never increased. The ConnectionResetError
is caught inside the inner read loop, which calls `disconnect()` + `break` — but
neither path increases the backoff. The outer `except Exception` handler that does
increase the backoff is never reached because the exception was already caught.

**Result:** The reconnect loop hammers the EVL at the minimum 10-second interval
indefinitely, preventing it from releasing the old session.

**Evidence from logs:**
```
Reconnection attempt in 10s  (repeated 5+ times in a row)
Connection error while reading data: [Errno 104] Connection reset by peer
```

**Fix:** Added `self._reconnect_time = min(self._reconnect_time * 2, _RECONNECT_MAX_TIME)`
in the inner read loop's `ConnectionResetError/OSError/BrokenPipeError` handler,
so the backoff increases even when the failure occurs after a successful TCP connect.

---

## Bug 11: Unhandled handler exceptions crash the connection

**File:** `envisalink_base_client.py` — `process_data()`

**Problem:** `process_data()` calls handler functions (e.g. `handle_keypad_update`,
`handle_command_response`) inside a try/except that only catches `AttributeError`,
`TypeError`, and `KeyError`. If a handler raises `ValueError` (e.g. `int()` on
corrupted non-numeric data) or `IndexError` (e.g. too-few-fields in the data),
the exception propagates to the outer `read_loop()` catch-all, which disconnects
and increases the backoff. Corrupted data from the EVL should not tear down the
connection.

**Fix:** Added a second `except Exception` clause in `process_data()` that catches
all remaining handler exceptions and logs them at warning level without
disconnecting.

---

## Bug 12: Keypad update validation rejects valid messages

**File:** `honeywell_client.py` — `handle_keypad_update()`, `honeywell_envisalinkdefs.py`

**Problem (a) — Overly broad `%` check:** The check `if "%" in data:` was
intended to detect fused multi-message lines (Bug 9), but also rejects any keypad
update whose alpha text field legitimately contains a `%` character (e.g. battery
percentage readout, or any panel label that includes `%`).

**Problem (b) — 4-field messages silently dropped:** `%00` keypad update messages
occasionally arrive with only 4 comma-separated fields instead of the normal 5
— the alpha display-text field is omitted by newer EVL-4 firmware during zone-trip
events. The validation `len(dataList) < 5` rejected these entirely, meaning zone
and partition state updates were silently lost, which in turn caused the subsequent
keepalive command to time out (no state change callback to wake the HA event loop).

**Problem (c) — `%00%00` code reported with no handler:** A field report suggested
that EVL-4 hardware occasionally sends `%00%00` as the TPI command code during
zone trips. `%00%00` was absent from `evl_ResponseTypes`, so `parseHandler` would
log a warning and skip the message entirely, dropping the zone state change.
This has **not been confirmed in raw logs** — the upstream maintainer notes there
are no known TPI protocol changes in newer firmware and that this would more likely
indicate a firmware bug or hardware issue. Raw packet logging (`RAW << %r`) has
been added to `envisalink_base_client.py` to capture evidence. If reproduced, the
maintainer will follow up with the Envisalink developers.

**Fix (a):** Removed the `"%" in data` check. Root cause is handled by the
message-framing fix (Bug 13).

**Fix (b):** Changed validation threshold from `< 5` to `< 4` (reject only if
fewer than 4 fields). Added an explicit `len(dataList) == 4` branch that appends
an empty string as the alpha field and continues processing normally.

**Fix (c) — precautionary:** Added a `%00%00` entry to `evl_ResponseTypes` in
`honeywell_envisalinkdefs.py` mapping it to the same `keypad_update` handler as
`%00`. This is a no-risk defensive addition — if the code never appears it has no
effect; if it does appear it prevents a silent message drop rather than crashing.
Raw logs will determine whether further investigation is needed.

---

## Bug 13: keepalive responses blocked by `readuntil` waiting for a newline

**File:** `alarm_panel.py`, `envisalink_base_client.py` — `read_loop()`

**Problem:** With the multi-message fix (Bug 9) in place, keepalive timeouts
continued to occur with 6-10+ second delays. Initial analysis attributed these
to the EVL being slow under load and increased `commandTimeout` from 5 s to 30 s
as a workaround. Envisacor later confirmed that on-device latency is always
< 500 ms — the delays were not caused by the EVL at all.

The actual cause is `readuntil(b"\n")`: the EVL sends `^00,00$` as the keepalive
response without a trailing `\r\n`, or fused to the front of the next unsolicited
message. `readuntil` does not return until `\n` is found, so the response sits in
the OS receive buffer — while the command timeout clock keeps running in
`process_command_queue` — until the next `\r\n`-terminated message arrives, which
can be 6-10 seconds later.

The Bug 9 fix (splitting on `$` after `readuntil` returns) correctly addressed
fused-message parsing but still depended on `readuntil` completing first. A
response arriving without its own `\r\n` continued to block until the next
newline. The 30 s timeout extension masked the symptom without addressing the
cause.

**Evidence (original):**
```
21:34:12 - '00' timeout (single, then 8 successful keepalives)
21:43:12 - '00' timeout (EVL busy with panel events for ~15s)
21:43:17 - '03' timeout
21:43:22 - '03' timeout → 3 consecutive → disconnect
```

**Fix:** Replace `readuntil(b"\n")` with `read(4096)` backed by a persistent
`_recv_buffer` bytes object on the client instance. After each chunk is appended,
a loop extracts complete messages in priority order:

1. If `$` appears before `\n` (or no `\n` is present): extract up to and
   including `$` as a TPI message and process it **immediately**, without waiting
   for a newline. This covers all Honeywell and Uno command responses and events,
   including responses that arrive without a trailing `\r\n`.
2. Otherwise: extract up to and including `\n` — handles Honeywell login messages
   (`Login:`) and all DSC panel messages, which are always newline-terminated.

Fused messages (e.g. `%00,01,...$^00,00$\r\n`) are now parsed incrementally as
each `$` is encountered, superseding the Bug 9 post-hoc split (which is removed).
The `_recv_buffer` is cleared in `disconnect()` and initialised in `__init__`, so
stale data from a dead session is never re-processed.

`IncompleteReadError` (previously raised by `readuntil` on EOF) is removed;
`read()` returns `b""` on EOF, which is already handled as a clean disconnect.

With this fix, keepalive responses arrive within < 500 ms and the 30-second
`commandTimeout` workaround is no longer needed. The default `commandTimeout` is
restored to `5.0` seconds. The `_MAX_RETRY_DELAY = 10` constant is retained as a
sound independent improvement that decouples the retry cap from the command
timeout.

**Secondary effect — false "EVL silent" disconnects eliminated:** The 3-consecutive-
timeout disconnect check in `process_command_queue` tests whether the EVL has been
silent for longer than `command_timeout` to avoid disconnecting a live EVL that is
just slow. The silence duration is measured via `_lastReceivedTime`. With
`readuntil`, this timestamp was only updated when a `\n`-terminated line was
returned — bytes sitting in the TCP buffer without a trailing newline were
invisible. This meant `_lastReceivedTime` could be 82–209 s stale while the EVL
was actually alive and responding, causing the silence check to fire incorrectly
and trigger a spurious disconnect. With `read()`, `_lastReceivedTime` is updated
on every raw TCP chunk, so any data from the EVL — newline or not — keeps the
timer fresh.

---

## Bug 14: Bare `%XX` notification fused with `^YY` command response loses the command acknowledgement

**File:** `envisalink_base_client.py` — `read_loop()`

**Problem:** Newer EVL-4 firmware occasionally sends a bare notification code (e.g.
`%02` — partition state change) with no data fields and no `$` frame terminator,
directly concatenated with the command acknowledgement, producing a single line
like:

```
%02^00,00$\r\n
```

With `readuntil(b"\n")` (original code) or the streaming buffer (Bug 13 fix), this
arrives as the single message `%02^00,00$`. The `parseHandler` regex
`([%\^].+)\$` captures `%02^00,00` as the message content; splitting on `,` gives
code `%02^00`. There is no handler registered for that code, so `parseHandler`
logs:

```
No handler defined in config for %02^00, skipping...
```

...and returns. The `^00` command response is never passed to `command_succeeded`,
so the keepalive is counted as a timeout. This is distinct from the Bug 9/13
fused-message cases — those are two fully formed `$`-terminated messages on one
line; this is a partially formed `%XX` code with the `$` missing entirely.

**Evidence (observed in production logs):**
```
WARNING No handler defined in config for %02^00, skipping...
```

**Fix:** After extracting and decoding each message in the read loop, detect the
fused pattern before calling `process_data`: if the message starts with `%` and
the `^` character appears before the first `,` (i.e. in the code position rather
than a data field), split at `^` and process the two parts independently:

- `%02$` → dispatched to `handle_partition_state_change`, which is a no-op stub
  for Honeywell panels and returns safely with empty data.
- `^00,00$` → dispatched to `handle_command_response` → keepalive acknowledged. ✓

The split is skipped if `^` appears only inside a data field (after the first
comma), so legitimate alpha text in `%00` keypad updates is unaffected.

**Related noise: "Late command acknowledgement" warning** — a secondary symptom
of the same firmware fusion. When the `^00` ack is delayed past the 5 s timeout
(because it was trapped in a fused message), the command expires and is removed
from the queue. If the ack then arrives on a subsequent line, `command_succeeded`
fires with an empty queue and logs:
```
Late command acknowledgement received for '00' (no pending command).
```
This is not an error — `_consecutive_timeouts` is reset to 0 regardless, so the
EVL is correctly recognised as alive. With Bugs 13 and 14 fixed, this situation
should not arise. The log level is downgraded from WARNING to DEBUG since it is
not actionable.

---

## Bug 15: Non-ASCII garbage frames corrupt alarm state and trigger cascading errors

**File:** `envisalink_base_client.py` — `read_loop()`

**Problem:** Bug 6 changed the `UnicodeDecodeError` handler to fall back to
`errors="replace"` and continue processing the frame with `U+FFFD` replacement
characters standing in for the bad bytes. In practice this exposes a worse
problem: corrupted binary data from a stale or bleed-over TCP session can accidentally
match the protocol framing (`$`-terminated, starts with `%` or `^`), get decoded
with replacement characters substituted in, and then be forwarded to the protocol
handlers. The handlers then write garbage into the alarm state — setting sensor
values to replacement-character strings — and generate a chain of downstream
errors (`"Unrecognized data"`, `"too few fields"`, keypad sensor showing `***^00,00`).

**Evidence from logs:**
```
Received non-ASCII data from EVL, replacing invalid bytes:
  b'\x0ca\xa4@\xac\xccwYL\xb2\xe9l\n'
  b'\x9c\xdf\xed^\xc91"\xb4\xb2\xbb...<truncated>...000000000000$'

Unrecognized data received from the envisalink. Ignoring.   [×6]
Keypad data from Envisalink has too few fields (1), ignoring:  [×2]
```

**Fix:** Changed the `UnicodeDecodeError` handler to **discard** the corrupt frame
entirely instead of substituting replacement characters. A WARNING is still logged
(so the raw bytes are visible for hardware diagnosis), but the frame is skipped
with `continue` and the connection is NOT torn down. No garbage is forwarded to
any handler, preventing alarm state corruption.

The previous `errors="replace"` approach was a half-measure: it prevented a crash
but allowed corrupted content into the processing pipeline. Discarding is correct
because no valid TPI message can contain non-ASCII bytes — EVL TPI is pure ASCII.

---

## Bug 16: Command ACK mismatch logged at ERROR instead of WARNING

**File:** `envisalink_base_client.py` — `command_succeeded()`

**Problem:** When a command acknowledgement (`^XX,00$`) arrives while a *different*
command is at the head of the send queue, `command_succeeded` logs:
```
ERROR Command acknowledgement received is different for a different command (00)
       than was issued (03)
```
This triggered repeatedly in production logs (6+ occurrences, matching Bug 15's
corrupted session) and was classified as an ERROR — implying data loss or a
programming defect.

In reality this is an expected race: the EVL has no per-message sequence numbers.
When a keepalive (`00`) and a keypress (`03`) queue up back-to-back, the EVL may
send `^00,00$` (ack for keepalive) while the code has already advanced to waiting
for the `^03,00$` ack. The `^00` ack is simply late — it arrived after the
keepalive timed out and was dequeued. The in-flight `03` command is NOT advanced
(correct), `_consecutive_timeouts` is correctly reset to 0 (EVL is clearly alive),
and the `03` will receive its own ack shortly.

**Fix:** Changed log level from `ERROR` to `WARNING` and improved the message to
clarify that this is a late-ack scenario, not a protocol violation or data loss.

---

## Bug 17: Fused `%XX%YY` messages leak raw TPI data into keypad display

**Files:** `envisalink_base_client.py` — `read_loop()`, `honeywell_client.py` — `handle_keypad_update()`, addon `evl_client.py` — `_dispatch()`

**Problem:** After exiting programming mode (`*99`), the EVL occasionally sends
two `%00` keypad updates fused together without a `$` separator between them —
only the second message has the `$` terminator:

```
%00,01,1C08,00,01,Ready           %00,01,0067,00,01,***DISARMED***  Ready to Arm   $
```

The `$`-based buffer parser treats this entire string as a single message.  The
alpha recombination logic (`",".join(data_fields[4:])`) then joins the raw
`%00,XX,...` text from the second message into the alpha field of the first,
producing display text like:

```
Ready           %00,01,0067,00,01,***DISARMED***  Ready to Arm
```

The user briefly sees raw TPI protocol data on the keypad display or in the HA
sensor state.  This is the same class of EVL protocol quirk as Bug 14 (`%XX^YY`
fusion), but for `%XX%YY` patterns where both halves are `%`-prefixed messages.

**Fix (primary):** Extended the fused-packet splitter in `envisalink_base_client.py`
(and the addon's `evl_client.py`) to also detect `%XX%YY` patterns.  After the
existing Bug 14 `%XX^YY` check, a regex `(?<=.)%[0-9A-Fa-f]{2},` scans for a
second `%XX,` code (two hex digits followed by a comma) at any position after
index 0.  If found, the message is split at that position and each half is
dispatched independently — identical to the `%XX^YY` split.

The `%XX,` pattern (percent + two hex digits + comma) does not appear in
legitimate Vista panel display text (which uses only A-Z, 0-9, spaces, and
basic punctuation), so false positives are not a concern.

**Fix (safety net):** Added a 32-character alpha length check in both
`honeywell_client.py` `handle_keypad_update()` and addon `evl_client.py`
`_dispatch()`.  Vista panels have a 32-character display (16×2); any alpha
text exceeding this length indicates fused messages that slipped through the
buffer parser.  The alpha is truncated with a DEBUG log so the display
remains clean even if a new fusion pattern is discovered.

---

## Bug 18: Command ACKs without trailing `$` cause keepalive timeouts

**File:** `envisalink_base_client.py` — `read_loop()` buffer extraction

**Problem:** The EVL firmware sometimes sends command acknowledgements (`^CC,EE`)
without a trailing `$` terminator. These 6-byte responses are well-formed but sit
in the receive buffer waiting for a `$` or `\n` delimiter that never arrives
independently. By the time the next `$`-terminated message arrives and the
buffer gets parsed, the 5-second command timeout has already fired and the
keepalive is counted as failed.

This is distinct from Bug 13 (responses blocked by `readuntil` waiting for `\n`)
— Bug 13 was about the `readuntil` API itself. Bug 18 affects the `read(4096)`
streaming buffer introduced by the Bug 13 fix: the `$`/`\n` delimiter search
can still miss a bare `^CC,EE` that arrives without either delimiter.

**Fix:** Added a "Priority 1" extraction step at the top of the buffer parsing
loop. Before looking for `$` or `\n` delimiters, a regex `^\^[0-9A-Fa-f]{2},
[0-9A-Fa-f]{2}` is tested against the buffer head. If it matches, the 6-byte
command response is extracted immediately, the optional trailing `$` is consumed
if present, and the reconstructed message (`^CC,EE$`) is dispatched to
`process_data`. This unblocks the command queue within milliseconds of the ACK
arriving, regardless of whether a `$` terminator was included.

---

## Bug 19: Unified fused-message splitter with compound code awareness

**Files:** `envisalink_base_client.py` — `_split_fused_messages()`

**Problem:** Bugs 14 and 17 each added separate fused-message detection: Bug 14
checked for `%XX^YY` (notification + command response), Bug 17 checked for
`%XX%YY` (two notifications). These were implemented as inline code in the read
loop, each with its own regex and splitting logic. This left gaps for untested
combinations (`^XX%YY`, `^XX^YY`) and had a false-positive risk: the compound
response code `%00%00` (Bug 12c) looks exactly like a `%XX%YY` fused pair and
would be incorrectly split, dropping the zone-trip second half.

**Fix:** Replaced the separate inline checks with a unified `_split_fused_messages()`
method. After the initial 3-character TPI code, the method scans for any second
sentinel pattern (`%XX` or `^XX`, where XX is two hex digits) using a compiled
regex. Before splitting at position 3 (immediately after the first code), it
checks whether the 6-character prefix is a known compound code in
`_evl_ResponseTypes` — if so (e.g. `%00%00`), the match is skipped and the
message is processed as a single unit. For all other positions or unknown
compounds, the message is split and each half is dispatched independently.

The method is recursive, so triple-fusion or deeper (should the EVL ever produce
such output) is handled automatically. All four fusion patterns are covered:
`%XX%YY`, `%XX^YY`, `^XX%YY`, `^XX^YY`.

---

## Bug 20: Missing `await` in `keypresses_to_default_partition`

**File:** `envisalink_base_client.py` — `keypresses_to_default_partition()`

**Problem:** The call to `self.send_data(keypresses)` was missing its `await`.
`send_data()` is a coroutine that queues the data for TCP transmission. Without
`await`, the method returned a coroutine object instead of actually sending
the data. Python issues a "coroutine was never awaited" runtime warning, and
the keypress is silently dropped.

This primarily affected the addon's HA-mode key sending path, where
`keypresses_to_default_partition` is the entry point for sending programming
keys via the HA REST API.

**Fix:** Added `await` to the `self.send_data(keypresses)` call.

---

## Bug 21: Adaptive read timeout — login vs. normal operation

**File:** `envisalink_base_client.py` — `read_loop()`

**Problem:** The `read(4096)` call used a fixed 5-second `asyncio.wait_for`
timeout. During normal operation, the EVL sends periodic keypad updates every
5–10 seconds. A 5-second read timeout meant that roughly half of normal idle
cycles would hit `TimeoutError`, triggering the timeout handler, generating DEBUG
log noise, and wasting CPU on exception handling — all for a completely normal
condition (no data arrived during a quiet 5-second window).

During login, however, a 5-second timeout is appropriate: if the EVL doesn't
send the `Login:` prompt within a few seconds of TCP connect, something is wrong
(wrong port, non-EVL device, firmware issue), and we should detect this quickly
rather than waiting 30 seconds.

**Fix:** Changed to an adaptive timeout: 5 seconds while `_loggedin` is False
(login handshake), 30 seconds once logged in (normal operation). The 30-second
normal timeout matches the typical keepalive interval, so a timeout during
normal operation genuinely indicates the EVL has gone silent and warrants
investigation. The login-phase timeout check also verifies against
`connection_timeout` before disconnecting, so brief login delays don't cause
premature disconnects.

---

## Bug 22: Keepalive commands queue up during heavy traffic and time out

**File:** `envisalink_base_client.py` — `periodic_command()`

**Problem:** The `periodic_command()` function fires every `keepAliveInterval`
seconds and enqueues a keepalive (`'00'`) or zone timer dump (`'02'`) command.
The command pipeline is sequential — only one command is in-flight at a time.
During heavy addon scanning (rapid keypress sequences), the command queue backs
up with `'03'` (PartitionKeypress) commands. The periodic keepalive gets added
to the end of the queue, waits behind all the keypress commands, and by the time
it reaches the front, the 5-second command timeout has already expired.

Three consecutive timeouts trigger a disconnect (Bug 1 fix), so a sufficiently
long scanning session would accumulate enough keepalive timeouts to tear down
the TCP connection mid-scan.

Additionally, during normal operation the EVL is continuously sending `%00`
keypad updates (every 5–10 seconds). Receiving any data from the EVL confirms
the TCP session is alive — sending a keepalive probe is redundant.

**Fix:** `periodic_command()` now checks two conditions before enqueuing:

1. **Queue busy:** If `_commandQueue` is non-empty, the keepalive/dump is
   skipped. In-flight commands already prove the connection is alive.
2. **Recent RX:** If data was received from the EVL within the keepalive
   interval (`_lastReceivedTime` is fresh), the keepalive is skipped. Any
   incoming data proves the connection is alive.

If neither condition is met, the keepalive is sent normally. Skips are logged
at DEBUG level.

---

## Bug 23: Programming mode keypad updates crash handler and suppress HA sensor updates

**Files:** `honeywell_client.py` — `handle_keypad_update()`, `sensor.py` — `EnvisalinkKeypadSensor`

**Problem:** During programming mode (e.g. `*20`, `*56`, `*82`), the panel sends
`%00` keypad updates where the user/zone field (`dataList[2]`) contains values
that are not valid zone numbers — typically `0`, or address/field values like `193`,
`195`, etc. The handler enters the `elif user_zone_field is not None:` branch and
eventually reaches `alarm_state["zone"][user_zone_field]`, which raises a `KeyError`
because the zone dict only contains keys 1–128.

This `KeyError` propagates up to `process_data()` in `envisalink_base_client.py`,
where it is caught by the generic `except (AttributeError, TypeError, KeyError)`
handler. This leaves `result = None`, so `handle_state_change_callbacks()` is never
called. The partition status dict — including the alpha display text — has already
been updated at this point (the `.update()` call is unconditional at the top of
the method), but the callback that tells HA about the change is never triggered.

The HA sensor entity (`sensor.alarm_partition_1_keypad`) therefore misses every
display update that occurs during programming mode. The user sees gaps in the
sensor's Activity history: e.g. "Keypad Addr.20 193" → gap → "Field?" → "Field? 1"
→ "Field? 19", with the intermediate zone data displays missing entirely.

The same `KeyError` risk existed in the zone timer expiry loop lower in the method,
where `alarm_state["zone"][int(timer[0])]` could reference an invalid zone number
if a timer had been incorrectly created for a non-zone value.

**Fix (a) — zone validation:** Before accessing `alarm_state["zone"]`, the method
now checks `valid_zone = user_zone_field in self._alarmPanel.alarm_state["zone"]`.
If the zone number is invalid, the zone state update is skipped with a DEBUG log
message, but the method continues to completion and returns its `results` dict
normally — so the partition state callback always fires.

**Fix (b) — timer expiry guard:** The timer expiry loop now validates each zone
number before accessing `alarm_state["zone"]` and skips invalid entries.

**Fix (c) — `force_update` on sensor:** Added `self._attr_force_update = True` to
`EnvisalinkKeypadSensor.__init__()`. This tells HA to always fire a `state_changed`
event when `async_write_ha_state()` is called, even if the sensor's `native_value`
and attributes are identical to the previous state. During programming mode, the
panel may re-send the same display text multiple times (e.g. scrolling back to an
already-seen field); without `force_update`, HA suppresses the duplicate and the
addon's WebSocket listener misses it.

---

## Bug 24: Keepalive retry waits full 60s interval after command timeout

**File:** `envisalink_base_client.py` — `periodic_command()`

**Problem:** When a keepalive command timed out (1/3 consecutive timeouts),
`periodic_command()` slept for the full 60-second keepalive interval before
retrying. With the 3-timeout disconnect threshold, detecting a dead connection
took ~4 minutes (3 × 60s cycles + command timeouts). Users saw
`last_rx_age=102.2s` warnings with long gaps before reconnection.

**Fix:** After executing the periodic action, if `_consecutive_timeouts > 0`
the sleep is shortened to 10 seconds instead of the full interval. This
reduces dead-connection detection from ~4 minutes to ~30 seconds (3 × 10s).
The shortened interval is logged at DEBUG level.

---

## Files Changed

- `custom_components/envisalink_new/pyenvisalink/envisalink_base_client.py` — Bugs 1-22, 24; ISSUE-DIAG removal
- `custom_components/envisalink_new/pyenvisalink/honeywell_client.py` — Bugs 9, 12, 17, 23; Bug23 log removal
- `custom_components/envisalink_new/pyenvisalink/honeywell_envisalinkdefs.py` — Bug 12c (`%00%00` handler entry)
- `custom_components/envisalink_new/pyenvisalink/alarm_panel.py` — Bug 13 (`commandTimeout` restored to 5.0)
- `custom_components/envisalink_new/sensor.py` — Bug 23c (`force_update`)

## Testing

- Tested on EVL-4 with Honeywell panel over multiple days
- Verified keepalive timeouts no longer trigger disconnects
- Verified reconnect backoff increases properly after connection failures
- Verified arm/disarm operations work correctly after reconnection
- Verified network blip recovery without cascading errors
- Verified programming mode keypad updates appear in HA sensor history
- Verified dead-connection detection within ~30s (Bug 24)
