### PR TITLE
Fix Honeywell arming: report ARMING during the exit-delay countdown

### DIFF
--- a/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
+++ b/custom_components/envisalink_new/pyenvisalink/honeywell_client.py
@@ -246,13 +246,23 @@ class HoneywellClient(EnvisalinkClient):
             "armed_bypass"
         ]
 
+        # Honeywell keeps the armed_away/armed_stay LED flag asserted during the
+        # exit-delay countdown ("You may exit now"), which made HA jump straight to
+        # ARMED_AWAY/ARMED_HOME and skip the ARMING state entirely. get_partition_state()
+        # already detects the countdown as "arming"; surface that as the exit_delay
+        # flag and withhold armed_away/armed_stay until the countdown finishes -- the
+        # same status-dict contract the DSC handler uses (armed_* False + exit_delay
+        # True while arming). Disarm during the countdown is unaffected (separate
+        # command path) and correctly reports arming -> disarmed.
+        is_arming = partition_status == "arming"
+
         # TODO "armed_bypass" is included in the state below but just passes the bypass flag.
         # How is that used?
         self._alarmPanel.alarm_state["partition"][partitionNumber]["status"].update(
             {
                 "alarm": bool(flags.alarm),
                 "alarm_in_memory": bool(flags.alarm_in_memory),
-                "armed_away": bool(flags.armed_away),
+                "armed_away": bool(flags.armed_away) and not is_arming,
                 "ac_present": bool(flags.ac_present),
                 "armed_bypass": bool(flags.bypass),
                 "chime": bool(flags.chime),
@@ -261,7 +271,8 @@ class HoneywellClient(EnvisalinkClient):
                 "trouble": bool(flags.system_trouble),
                 "ready": bool(flags.ready),
                 "fire": bool(flags.fire),
-                "armed_stay": bool(flags.armed_stay),
+                "armed_stay": bool(flags.armed_stay) and not is_arming,
+                "exit_delay": is_arming,
                 "alpha": alpha,
                 "beep": beep,
                 "armed_night": armed_night,


### PR DESCRIPTION
### Problem

On a Honeywell panel, arming never surfaces the `ARMING` state in Home Assistant — the `alarm_control_panel` entity jumps straight to `armed_away`/`armed_home` the instant you arm, even though the panel is still in its exit-delay countdown ("You may exit now", continuous slow beep).

That's wrong for anything keying on the state: automations, notifications, and touchpanel UIs think the house is fully armed while the exit window is still running.

### Root cause

Honeywell keeps the `armed_away`/`armed_stay` panel LED flag asserted **during** the exit-delay countdown. In `HoneywellClient.handle_keypad_update()`:

- `armed_away`/`armed_stay` are written to the status dict straight from the flags, so they read `True` immediately.
- `exit_delay` is **never set** in the status dict (it stays at its `alarm_state.py` default of `False`).

`get_partition_state()` *does* detect the countdown as `"arming"` (from the `"You may exit now"` alpha text) — but that result is only logged (`"Keypad is counting down to arm"`), never written into the status dict.

Meanwhile the `AlarmControlPanelEntity.alarm_state` property checks `armed_away`/`armed_stay` **before** `exit_delay`, so even the `ARMING` branch is unreachable.

### Fix

Derive `exit_delay` from the `"arming"` state the client already computes, and withhold `armed_away`/`armed_stay` until the countdown finishes — matching the exact status-dict contract the DSC handler already uses (`armed_* = False` + `exit_delay = True` while arming). No change needed to the shared state mapping.

```python
is_arming = partition_status == "arming"
...
"armed_away": bool(flags.armed_away) and not is_arming,
"armed_stay": bool(flags.armed_stay) and not is_arming,
"exit_delay": is_arming,
```

### Result

`disarmed → arming (exit delay) → armed_away`, matching DSC and the physical keypad. Disarm during the countdown is unaffected (it's a separate command path) and correctly transitions `arming → disarmed`.

### Testing

Verified against a live Honeywell + EVL4 (`panel_type: HONEYWELL`, `evl_version: 4MAX`). The keypad reports `"ARMED ***AWAY***You may exit now"` with a `continuous slow beep` during the exit delay; with this change the entity reports `arming` for that window and transitions to `armed_away` when it completes, and a disarm mid-countdown returns it to `disarmed`.

Note: `entry_delay`/`PENDING` has the same underlying gap (there's a pre-existing `# TODO Add entry_delay to %00 update handler`) and is intentionally left out here to keep this focused on the exit-delay/arming path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)