### PR TITLE
Fix Uno MajorTrouble_Flags.__str__ AttributeError freezing 5 partition sensors

### DIFF
--- a/custom_components/envisalink_new/pyenvisalink/uno_envisalinkdefs.py
+++ b/custom_components/envisalink_new/pyenvisalink/uno_envisalinkdefs.py
@@ -35,7 +35,7 @@ class MajorTrouble_Flags(ctypes.Union):
             f"0x{int(self.asByte):02x}"
             f" service_required={self.service_required}"
             f" ac_failure={self.ac_failure}"
-            f" wireless_device_low_Battery={self.wireless_device_low_Battery}"
+            f" wireless_device_low_battery={self.wireless_device_low_battery}"
             f" server_offline={self.server_offline}"
             f" zone_trouble={self.zone_trouble}"
             f" system_battery_overcurrent={self.system_battery_overcurrent}"


### PR DESCRIPTION
## What

One-character fix: `MajorTrouble_Flags.__str__` referenced `wireless_device_low_Battery` (capital B) while the `MajorTrouble_Bitfield` field is declared `wireless_device_low_battery`.

```diff
-            f" wireless_device_low_Battery={self.wireless_device_low_Battery}"
+            f" wireless_device_low_battery={self.wireless_device_low_battery}"
```

## Why it matters

The mismatch was introduced in 3a31edf (#214), which renamed the bitfield member to lowercase but left the `__str__` reference capitalized.

On Uno panels, `handle_partition_trouble_state_change` logs the flags via an f-string **before** any status assignments:

```python
_LOGGER.debug(f'Partition {partitionNumber} has new trouble state {flags}')  # raises AttributeError here
status['trouble'] = ...          # never reached
status['ac_present'] = ...
status['bat_trouble'] = ...
status['bell_trouble'] = ...
status['zone_low_battery'] = ...
```

The f-string is built eagerly regardless of log level, so every partition trouble update (`%06`) raised `AttributeError`, which the handler loop in `envisalink_base_client` caught and `continue`d — so no status was written and no state-change callback fired. Five Uno partition sensors were permanently stuck at their defaults: `ac_present` (AC Power stuck on), `trouble`, `bat_trouble`, `bell_trouble`, and `zone_low_battery` — the last being the sensor #214 set out to add.

DSC is unaffected (it derives low battery from alpha/zone codes, not `MajorTrouble_Flags`), and Uno has no fallback since `UnoClient.handle_keypad_update` returns `None`.

## Testing

Reproduced the observed log error, then confirmed the patched `__str__` renders without raising and reads the low-battery bit correctly:

```
str() -> 0x04 service_required=0 ac_failure=0 wireless_device_low_battery=1 ...
```

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)
